### PR TITLE
Crash on after authorization success

### DIFF
--- a/SDK/API/HTBHatenaBookmarkAPIClient.m
+++ b/SDK/API/HTBHatenaBookmarkAPIClient.m
@@ -111,6 +111,7 @@ static NSDictionary * HTBParametersFromQueryString(NSString *queryString) {
             
             currentRequestToken.verifier = [HTBParametersFromQueryString([url query]) valueForKey:@"oauth_verifier"];
             [self acquireOAuthAccessTokenWithPath:KHatenaOAuthAccessTokenPath requestToken:currentRequestToken accessMethod:@"POST" success:^(AFOAuth1Token * accessToken, id responseObject) {
+                [[NSNotificationCenter defaultCenter] removeObserver:_applicationLaunchNotificationObserver];
                 _applicationLaunchNotificationObserver = nil;
                 if (accessToken) {
                     self.accessToken = accessToken;
@@ -123,6 +124,7 @@ static NSDictionary * HTBParametersFromQueryString(NSString *queryString) {
                     }
                 }
             } failure:^(NSError *error) {
+                [[NSNotificationCenter defaultCenter] removeObserver:_applicationLaunchNotificationObserver];
                 _applicationLaunchNotificationObserver = nil;
                 if (failure) {
                     failure(error);


### PR DESCRIPTION
Step to reproduce
1. Set up consumer key/secret in demo app.
2. Launch demo app.
3. Push login button.
4. Authorization view appeared. After succeeding authorization, it crashes once to about twice. 

I investigated some similar problems.

http://stackoverflow.com/questions/7814917/thread-6-com-apple-nsurlconnectionloader-program-received-signal-exc-bad-acce
https://github.com/AFNetworking/AFNetworking/issues/357
https://github.com/AFNetworking/AFNetworking/issues/907

I tried to fix by referring to the information above, but did not resolve.

I tried:

``` objc
[[NSURLCache sharedURLCache] setMemoryCapacity:0];
[[NSURLCache sharedURLCache] setDiskCapacity:0];
```

also tried:

``` objc
@interface NSURLRequest()

+ (void)setAllowsAnyHTTPSCertificate:(BOOL)b forHost:(NSString *)host;

@end

@implementation HTBAppDelegate

- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
{
    [NSURLRequest setAllowsAnyHTTPSCertificate:YES forHost:@"www.hatena.ne.jp"];
```

Attached crash log and screenshots.
Please refer to it.

![2013-08-09 23 14 07](https://f.cloud.github.com/assets/40610/938447/7b8fd338-00fe-11e3-9732-a77282eabda2.png)
![2013-08-09 23 16 22](https://f.cloud.github.com/assets/40610/938451/922521ca-00fe-11e3-9f6e-a9f018f9aa63.png)

```
Incident Identifier: 25A1A835-98AF-4A31-9771-EB97C0CE71AE
CrashReporter Key:   a3427d5078d91ee157f4bfbe192312c12fdbcbc6
Hardware Model:      iPhone5,2
Process:         DemoApp [36263]
Path:            /var/mobile/Applications/ADF4FA42-DE32-441B-B427-DBE75D088A0F/DemoApp.app/DemoApp
Identifier:      DemoApp
Version:         ??? (???)
Code Type:       ARM (Native)
Parent Process:  launchd [1]

Date/Time:       2013-08-09 23:25:09.603 +0900
OS Version:      iOS 6.1.4 (10B350)
Report Version:  104

Exception Type:  EXC_BAD_ACCESS (SIGSEGV)
Exception Codes: KERN_INVALID_ADDRESS at 0x00000020
Crashed Thread:  5

Thread 0 name:  Dispatch queue: com.apple.main-thread
Thread 0:
0   libsystem_kernel.dylib          0x39810e30 mach_msg_trap + 20
1   libsystem_kernel.dylib          0x39810fd0 mach_msg + 48
2   CoreFoundation                  0x316072b6 __CFRunLoopServiceMachPort + 126
3   CoreFoundation                  0x31605fd6 __CFRunLoopRun + 814
4   CoreFoundation                  0x31579238 CFRunLoopRunSpecific + 352
5   CoreFoundation                  0x315790c4 CFRunLoopRunInMode + 100
6   GraphicsServices                0x35158336 GSEventRunModal + 70
7   UIKit                           0x334952b4 UIApplicationMain + 1116
8   DemoApp                         0x000081dc 0x7000 + 4572
9   DemoApp                         0x00008164 0x7000 + 4452

Thread 1 name:  Dispatch queue: com.apple.libdispatch-manager
Thread 1:
0   libsystem_kernel.dylib          0x398115d0 kevent64 + 24
1   libdispatch.dylib               0x3974cd22 _dispatch_mgr_invoke + 806
2   libdispatch.dylib               0x39748374 _dispatch_mgr_thread + 32

Thread 2 name:  WebThread
Thread 2:
0   libsystem_kernel.dylib          0x39810e30 mach_msg_trap + 20
1   libsystem_kernel.dylib          0x39810fd0 mach_msg + 48
2   CoreFoundation                  0x316072b6 __CFRunLoopServiceMachPort + 126
3   CoreFoundation                  0x3160602c __CFRunLoopRun + 900
4   CoreFoundation                  0x31579238 CFRunLoopRunSpecific + 352
5   CoreFoundation                  0x315790c4 CFRunLoopRunInMode + 100
6   WebCore                         0x37581390 RunWebThread(void*) + 440
7   libsystem_c.dylib               0x3977a0de _pthread_start + 306
8   libsystem_c.dylib               0x39779fa4 thread_start + 4

Thread 3 name:  JavaScriptCore::BlockFree
Thread 3:
0   libsystem_kernel.dylib          0x3982108c __psynch_cvwait + 24
1   libsystem_c.dylib               0x39772afc _pthread_cond_wait + 644
2   libsystem_c.dylib               0x39772870 pthread_cond_timedwait + 40
3   JavaScriptCore                  0x3554edf6 WTF::ThreadCondition::timedWait(WTF::Mutex&, double) + 102
4   JavaScriptCore                  0x35661532 JSC::BlockAllocator::blockFreeingThreadMain() + 78
5   JavaScriptCore                  0x35674030 WTF::wtfThreadEntryPoint(void*) + 12
6   libsystem_c.dylib               0x3977a0de _pthread_start + 306
7   libsystem_c.dylib               0x39779fa4 thread_start + 4

Thread 4 name:  JavaScriptCore::Marking
Thread 4:
0   libsystem_kernel.dylib          0x3982108c __psynch_cvwait + 24
1   libsystem_c.dylib               0x39772afc _pthread_cond_wait + 644
2   libsystem_c.dylib               0x3977ccf8 pthread_cond_wait + 36
3   JavaScriptCore                  0x355f46dc JSC::SlotVisitor::drainFromShared(JSC::SlotVisitor::SharedDrainMode) + 140
4   JavaScriptCore                  0x355f4620 JSC::MarkStackThreadSharedData::markingThreadMain() + 140
5   JavaScriptCore                  0x35674030 WTF::wtfThreadEntryPoint(void*) + 12
6   libsystem_c.dylib               0x3977a0de _pthread_start + 306
7   libsystem_c.dylib               0x39779fa4 thread_start + 4

Thread 5 name:  com.apple.NSURLConnectionLoader
Thread 5 Crashed:
0   CFNetwork                       0x312ca4ba PersistentCredentialStorage::copyDefaultCredentialForProtectionSpace(_CFURLProtectionSpace*) + 22
1   CFNetwork                       0x312cb756 CFURLCredentialStorageCopyDefaultCredentialForProtectionSpace + 38
2   CFNetwork                       0x312ffd98 HTTPProtocol::_CFHTTPProtHasCredentialsForChallenge(__CFHTTPMessage*) + 1484
3   CFNetwork                       0x312ff390 HTTPProtocol::attemptAuthentication(__CFHTTPMessage*) + 48
4   CFNetwork                       0x3129230e HTTPProtocol::performHeaderRead() + 670
5   CFNetwork                       0x31292036 HTTPProtocol::httpReadStreamEvent(unsigned long) + 86
6   CFNetwork                       0x31332d54 CoreReadStreamClient::coreStreamEventsAvailable(unsigned long) + 32
7   CFNetwork                       0x313353d4 CoreStreamBase::_callClientNow() + 44
8   CoreFoundation                  0x316078f4 __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 12
9   CoreFoundation                  0x31607158 __CFRunLoopDoSources0 + 208
10  CoreFoundation                  0x31605f2a __CFRunLoopRun + 642
11  CoreFoundation                  0x31579238 CFRunLoopRunSpecific + 352
12  CoreFoundation                  0x315790c4 CFRunLoopRunInMode + 100
13  Foundation                      0x31ec6888 +[NSURLConnection(Loader) _resourceLoadLoop:] + 304
14  Foundation                      0x31f4a22c __NSThread__main__ + 968
15  libsystem_c.dylib               0x3977a0de _pthread_start + 306
16  libsystem_c.dylib               0x39779fa4 thread_start + 4

Thread 6 name:  WebCore: CFNetwork Loader
Thread 6:
0   libsystem_kernel.dylib          0x39810e30 mach_msg_trap + 20
1   libsystem_kernel.dylib          0x39810fd0 mach_msg + 48
2   CoreFoundation                  0x316072b6 __CFRunLoopServiceMachPort + 126
3   CoreFoundation                  0x3160602c __CFRunLoopRun + 900
4   CoreFoundation                  0x31579238 CFRunLoopRunSpecific + 352
5   CoreFoundation                  0x315790c4 CFRunLoopRunInMode + 100
6   WebCore                         0x3761bccc WebCore::runLoaderThread(void*) + 140
7   JavaScriptCore                  0x35674030 WTF::wtfThreadEntryPoint(void*) + 12
8   libsystem_c.dylib               0x3977a0de _pthread_start + 306
9   libsystem_c.dylib               0x39779fa4 thread_start + 4

Thread 7 name:  com.apple.CFSocket.private
Thread 7:
0   libsystem_kernel.dylib          0x39821594 __select + 20
1   CoreFoundation                  0x3160b474 __CFSocketManager + 676
2   libsystem_c.dylib               0x3977a0de _pthread_start + 306
3   libsystem_c.dylib               0x39779fa4 thread_start + 4

Thread 8:
0   libsystem_kernel.dylib          0x39821d98 __workq_kernreturn + 8
1   libsystem_c.dylib               0x3976fad6 _pthread_workq_return + 14
2   libsystem_c.dylib               0x3976f7f2 _pthread_wqthread + 362
3   libsystem_c.dylib               0x3976f680 start_wqthread + 4

Thread 9 name:  WebCore: LocalStorage
Thread 9:
0   libsystem_kernel.dylib          0x3982108c __psynch_cvwait + 24
1   libsystem_c.dylib               0x39772afc _pthread_cond_wait + 644
2   libsystem_c.dylib               0x3977ccf8 pthread_cond_wait + 36
3   JavaScriptCore                  0x3554edc8 WTF::ThreadCondition::timedWait(WTF::Mutex&, double) + 56
4   WebCore                         0x37795e7c WTF::PassOwnPtr<WebCore::StorageTask> WTF::MessageQueue<WebCore::StorageTask>::waitForMessageFilteredWithTimeout<bool (WebCore::StorageTask*)>(WTF::MessageQueueWaitResult&, bool (&)(WebCore::StorageTask*), double) + 52
5   WebCore                         0x37795e30 WebCore::StorageThread::threadEntryPoint() + 120
6   JavaScriptCore                  0x35674030 WTF::wtfThreadEntryPoint(void*) + 12
7   libsystem_c.dylib               0x3977a0de _pthread_start + 306
8   libsystem_c.dylib               0x39779fa4 thread_start + 4

Thread 10 name:  AFNetworking
Thread 10:
0   libsystem_kernel.dylib          0x39810e30 mach_msg_trap + 20
1   libsystem_kernel.dylib          0x39810fd0 mach_msg + 48
2   CoreFoundation                  0x316072b6 __CFRunLoopServiceMachPort + 126
3   CoreFoundation                  0x3160602c __CFRunLoopRun + 900
4   CoreFoundation                  0x31579238 CFRunLoopRunSpecific + 352
5   CoreFoundation                  0x315790c4 CFRunLoopRunInMode + 100
6   Foundation                      0x31e9d5be -[NSRunLoop(NSRunLoop) runMode:beforeDate:] + 250
7   Foundation                      0x31f40c40 -[NSRunLoop(NSRunLoop) run] + 76
8   DemoApp                         0x0004462e 0x7000 + 251438
9   Foundation                      0x31f4a22c __NSThread__main__ + 968
10  libsystem_c.dylib               0x3977a0de _pthread_start + 306
11  libsystem_c.dylib               0x39779fa4 thread_start + 4

Thread 11:
0   libsystem_kernel.dylib          0x39821d98 __workq_kernreturn + 8
1   libsystem_c.dylib               0x3976fad6 _pthread_workq_return + 14
2   libsystem_c.dylib               0x3976f7f2 _pthread_wqthread + 362
3   libsystem_c.dylib               0x3976f680 start_wqthread + 4

Thread 12:
0   libsystem_kernel.dylib          0x39821d98 __workq_kernreturn + 8
1   libsystem_c.dylib               0x3976fad6 _pthread_workq_return + 14
2   libsystem_c.dylib               0x3976f7f2 _pthread_wqthread + 362
3   libsystem_c.dylib               0x3976f680 start_wqthread + 4

Thread 13:
0   libsystem_kernel.dylib          0x39821d98 __workq_kernreturn + 8
1   libsystem_c.dylib               0x3976fad6 _pthread_workq_return + 14
2   libsystem_c.dylib               0x3976f7f2 _pthread_wqthread + 362
3   libsystem_c.dylib               0x3976f680 start_wqthread + 4

Thread 5 crashed with ARM Thread State (32-bit):
    r0: 0x1c58b5d0    r1: 0x00000000      r2: 0x312ca4a5      r3: 0x00000000
    r4: 0x00000000    r5: 0x1c58b5d0      r6: 0x00000000      r7: 0x049ffc30
    r8: 0x00000000    r9: 0x1d89dad0     r10: 0x00000000     r11: 0x00000000
    ip: 0x3992f738    sp: 0x049ffc0c      lr: 0x312cb759      pc: 0x312ca4ba
  cpsr: 0x60000030

Binary Images:
    0x7000 -    0x5bfff +DemoApp armv7s  <39527ee9b1933fbf8a333082537000f8> /var/mobile/Applications/ADF4FA42-DE32-441B-B427-DBE75D088A0F/DemoApp.app/DemoApp
 0x2ad6000 -  0x2adafff  AccessibilitySettingsLoader armv7s  <d735e03f72943aa7a3d4ca1b50b6d5df> /System/Library/AccessibilityBundles/AccessibilitySettingsLoader.bundle/AccessibilitySettingsLoader
 0x4135000 -  0x413cfff  GAXClient armv7s  <f61774ea020c3028977c16867da91eca> /System/Library/AccessibilityBundles/GAXClient.bundle/GAXClient
0x2fe79000 - 0x2fe99fff  dyld armv7s  <67efe80b9d863d6bb30fe51e6e17b070> /usr/lib/dyld
0x304ef000 - 0x3050afff  libJapaneseConverter.dylib armv7s  <05686f07f0da3fdf8d039e3a3706b30e> /System/Library/CoreServices/Encodings/libJapaneseConverter.dylib
0x30558000 - 0x3062afff  RawCamera armv7s  <3c08cb817a1132538a799beafa075302> /System/Library/CoreServices/RawCamera.bundle/RawCamera
0x30633000 - 0x3073dfff  IMGSGX543RC2GLDriver armv7s  <ee5266444586360499110498d57e09f5> /System/Library/Extensions/IMGSGX543RC2GLDriver.bundle/IMGSGX543RC2GLDriver
0x30747000 - 0x3082dfff  AVFoundation armv7s  <56f22385ccb73e31863f1fa9e0b621dd> /System/Library/Frameworks/AVFoundation.framework/AVFoundation
0x3082e000 - 0x3082efff  Accelerate armv7s  <f4e8c4c464953429ab6bd3160aadd176> /System/Library/Frameworks/Accelerate.framework/Accelerate
0x3082f000 - 0x3096cfff  vImage armv7s  <49d3cf19d0a23f4d836fc313e5fd6bab> /System/Library/Frameworks/Accelerate.framework/Frameworks/vImage.framework/vImage
0x3096d000 - 0x30a59fff  libBLAS.dylib armv7s  <584e045442be39fc847ffe1a5e4c99b2> /System/Library/Frameworks/Accelerate.framework/Frameworks/vecLib.framework/libBLAS.dylib
0x30a5a000 - 0x30d10fff  libLAPACK.dylib armv7s  <30a3e7dd8c603a9d81b5e42704ba5971> /System/Library/Frameworks/Accelerate.framework/Frameworks/vecLib.framework/libLAPACK.dylib
0x30d11000 - 0x30d69fff  libvDSP.dylib armv7s  <936354553eb93d2dafa76ffcad65f9b7> /System/Library/Frameworks/Accelerate.framework/Frameworks/vecLib.framework/libvDSP.dylib
0x30d6a000 - 0x30d7cfff  libvMisc.dylib armv7s  <5fae8715a0403315bb1991b79677f916> /System/Library/Frameworks/Accelerate.framework/Frameworks/vecLib.framework/libvMisc.dylib
0x30d7d000 - 0x30d7dfff  vecLib armv7s  <30275ee8819331229ba21256d7b94596> /System/Library/Frameworks/Accelerate.framework/Frameworks/vecLib.framework/vecLib
0x30d7e000 - 0x30d8ffff  Accounts armv7s  <df3255c62b0239f4995bc14ea79f106b> /System/Library/Frameworks/Accounts.framework/Accounts
0x30d91000 - 0x30df5fff  AddressBook armv7s  <ea949de12ca93a6a96ef80d0cb4d9231> /System/Library/Frameworks/AddressBook.framework/AddressBook
0x30ffd000 - 0x31286fff  AudioToolbox armv7s  <34857809ffa936a7a38f667aaa8ba316> /System/Library/Frameworks/AudioToolbox.framework/AudioToolbox
0x31287000 - 0x3134cfff  CFNetwork armv7s  <ef41814d8641319c96cdeb1264d2d150> /System/Library/Frameworks/CFNetwork.framework/CFNetwork
0x3134d000 - 0x313a3fff  CoreAudio armv7s  <19aa715b19a93a5c8563dbc706e899be> /System/Library/Frameworks/CoreAudio.framework/CoreAudio
0x313b7000 - 0x3156ffff  CoreData armv7s  <dee36bfc0c213492983c73d7bd83a27d> /System/Library/Frameworks/CoreData.framework/CoreData
0x31570000 - 0x316a2fff  CoreFoundation armv7s  <bd8e6c9f94b43e3d9af96a0f03ff3011> /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation
0x316a3000 - 0x317dcfff  CoreGraphics armv7s  <ef057fe1c715314cabf133ec26fa718c> /System/Library/Frameworks/CoreGraphics.framework/CoreGraphics
0x317de000 - 0x31819fff  libCGFreetype.A.dylib armv7s  <163d7f8309a6350399bbb1fef6cde32c> /System/Library/Frameworks/CoreGraphics.framework/Resources/libCGFreetype.A.dylib
0x319fd000 - 0x31a18fff  libRIP.A.dylib armv7s  <387d00a9ed55303b8936459a99869e07> /System/Library/Frameworks/CoreGraphics.framework/Resources/libRIP.A.dylib
0x31a19000 - 0x31acefff  CoreImage armv7s  <7d7cd7998a113ed9b483e7dc9f388b05> /System/Library/Frameworks/CoreImage.framework/CoreImage
0x31acf000 - 0x31b27fff  CoreLocation armv7s  <24dab19c71e831d187b56fe095483c16> /System/Library/Frameworks/CoreLocation.framework/CoreLocation
0x31b5c000 - 0x31bc1fff  CoreMedia armv7s  <526b25ed6f4e31b790553bd80d46fec7> /System/Library/Frameworks/CoreMedia.framework/CoreMedia
0x31bc2000 - 0x31c4afff  CoreMotion armv7s  <dfa016b3689c3ac99f33a0d774a44f2d> /System/Library/Frameworks/CoreMotion.framework/CoreMotion
0x31c4b000 - 0x31ca1fff  CoreTelephony armv7s  <930c89780b123ecea46cff85c4989982> /System/Library/Frameworks/CoreTelephony.framework/CoreTelephony
0x31ca2000 - 0x31d04fff  CoreText armv7s  <a01bc990cb483e828f7c3e08cd446daf> /System/Library/Frameworks/CoreText.framework/CoreText
0x31d05000 - 0x31d14fff  CoreVideo armv7s  <851591a704dc344aa2fc397094b4c622> /System/Library/Frameworks/CoreVideo.framework/CoreVideo
0x31e99000 - 0x3205cfff  Foundation armv7s  <0f73c35ada563c0bb2ce402d282faefd> /System/Library/Frameworks/Foundation.framework/Foundation
0x32217000 - 0x32260fff  IOKit armv7s  <4e5e55f27bbb35bab7af348997bfac17> /System/Library/Frameworks/IOKit.framework/Versions/A/IOKit
0x32261000 - 0x32439fff  ImageIO armv7s  <e04300f6e6b232ce8a02139d8f18dfdc> /System/Library/Frameworks/ImageIO.framework/ImageIO
0x324b3000 - 0x3264dfff  MediaPlayer armv7s  <3328573c20643b02806559249c749793> /System/Library/Frameworks/MediaPlayer.framework/MediaPlayer
0x3264e000 - 0x328c8fff  MediaToolbox armv7s  <1b36b1b41eca35989d2e822240a769cf> /System/Library/Frameworks/MediaToolbox.framework/MediaToolbox
0x32950000 - 0x329a9fff  MobileCoreServices armv7s  <b0d1162a8ab03529bb90e416895b568a> /System/Library/Frameworks/MobileCoreServices.framework/MobileCoreServices
0x329d6000 - 0x32a98fff  GLEngine armv7s  <0c748add2f663d76a29f23fa8a2b5fbc> /System/Library/Frameworks/OpenGLES.framework/GLEngine.bundle/GLEngine
0x32a99000 - 0x32aa0fff  OpenGLES armv7s  <c9c8f7cbfbe5397382286b878bdf143c> /System/Library/Frameworks/OpenGLES.framework/OpenGLES
0x32aa2000 - 0x32aa2fff  libCVMSPluginSupport.dylib armv7s  <b7d1ddfeb0db36d6af7293fa625b12be> /System/Library/Frameworks/OpenGLES.framework/libCVMSPluginSupport.dylib
0x32aa3000 - 0x32aa5fff  libCoreFSCache.dylib armv7s  <07390837fcda347e827279534d046989> /System/Library/Frameworks/OpenGLES.framework/libCoreFSCache.dylib
0x32aa6000 - 0x32aa8fff  libCoreVMClient.dylib armv7s  <8bcac434962435a895fa0b0a3a33b7a1> /System/Library/Frameworks/OpenGLES.framework/libCoreVMClient.dylib
0x32aa9000 - 0x32aadfff  libGFXShared.dylib armv7s  <272a9de67f6632c3aebbe2407cfe716b> /System/Library/Frameworks/OpenGLES.framework/libGFXShared.dylib
0x32aae000 - 0x32aedfff  libGLImage.dylib armv7s  <3a444257935236fab123e46e617c7a8d> /System/Library/Frameworks/OpenGLES.framework/libGLImage.dylib
0x32aee000 - 0x32c15fff  libGLProgrammability.dylib armv7s  <252e8c85f6f5374ba6b2690f7fc0e9c3> /System/Library/Frameworks/OpenGLES.framework/libGLProgrammability.dylib
0x331ed000 - 0x33301fff  QuartzCore armv7s  <b28fd354be3c38a2965e6368fa35e0c7> /System/Library/Frameworks/QuartzCore.framework/QuartzCore
0x33302000 - 0x3334efff  QuickLook armv7s  <2350b507fe1b3a1a94d2824e34649b36> /System/Library/Frameworks/QuickLook.framework/QuickLook
0x3334f000 - 0x3337dfff  Security armv7s  <e1fcc8913eba360c868f51558a01cf24> /System/Library/Frameworks/Security.framework/Security
0x333fc000 - 0x3343bfff  SystemConfiguration armv7s  <0fb8d4a2fa8f30ce837e068a046e466b> /System/Library/Frameworks/SystemConfiguration.framework/SystemConfiguration
0x3343e000 - 0x33991fff  UIKit armv7s  <62bee9294ca13738bd7ff14365dc8561> /System/Library/Frameworks/UIKit.framework/UIKit
0x33992000 - 0x339d1fff  VideoToolbox armv7s  <57487f6e3c38304ab0aa14dd16043f5c> /System/Library/Frameworks/VideoToolbox.framework/VideoToolbox
0x33c45000 - 0x33c66fff  AccessibilityUtilities armv7s  <6ba5de67ad0c31bb97f83b34643a7dad> /System/Library/PrivateFrameworks/AccessibilityUtilities.framework/AccessibilityUtilities
0x33c67000 - 0x33c73fff  AccountSettings armv7s  <c4b7436e8ea33ffd9805905f262e4479> /System/Library/PrivateFrameworks/AccountSettings.framework/AccountSettings
0x33cbf000 - 0x33cc2fff  AggregateDictionary armv7s  <52b69c81243d3e7ea280defa4802aa0f> /System/Library/PrivateFrameworks/AggregateDictionary.framework/AggregateDictionary
0x33dab000 - 0x33dbefff  AirTraffic armv7s  <e2261ffe1d803bc6bbed23191c848bad> /System/Library/PrivateFrameworks/AirTraffic.framework/AirTraffic
0x340ee000 - 0x34129fff  AppSupport armv7s  <7d6122cb42363dc981247c926e637a34> /System/Library/PrivateFrameworks/AppSupport.framework/AppSupport
0x3419c000 - 0x341a5fff  AssetsLibraryServices armv7s  <ec78d21573a23c34b6cec05ba56928f1> /System/Library/PrivateFrameworks/AssetsLibraryServices.framework/AssetsLibraryServices
0x341a6000 - 0x341bffff  AssistantServices armv7s  <2c462750e071380b924dda7cd3d0fcb6> /System/Library/PrivateFrameworks/AssistantServices.framework/AssistantServices
0x341d5000 - 0x341ecfff  BackBoardServices armv7s  <7fd28bde9e3b3a62a5758e9e859db9fb> /System/Library/PrivateFrameworks/BackBoardServices.framework/BackBoardServices
0x341f6000 - 0x3421afff  Bom armv7s  <f35bf1c1b24a3742847383801ac37505> /System/Library/PrivateFrameworks/Bom.framework/Bom
0x3429a000 - 0x342a1fff  CaptiveNetwork armv7s  <e308f6a4f4bf3749b56bd6ff4dd8b30a> /System/Library/PrivateFrameworks/CaptiveNetwork.framework/CaptiveNetwork
0x342a2000 - 0x3436cfff  Celestial armv7s  <a2f7438cb5163307a04d78bc2b8a86a9> /System/Library/PrivateFrameworks/Celestial.framework/Celestial
0x34450000 - 0x34455fff  CommonUtilities armv7s  <eb0b7e85b57e32f38dc498c0ee97aa7e> /System/Library/PrivateFrameworks/CommonUtilities.framework/CommonUtilities
0x3471b000 - 0x3471cfff  CoreSurface armv7s  <55826212d8b4352b87d80f93bc9b25c6> /System/Library/PrivateFrameworks/CoreSurface.framework/CoreSurface
0x34789000 - 0x3478efff  CrashReporterSupport armv7s  <3b190badb14f3771b353fcd829719c80> /System/Library/PrivateFrameworks/CrashReporterSupport.framework/CrashReporterSupport
0x34960000 - 0x34972fff  DataAccessExpress armv7s  <53ef646b265b3f5e944059baa19499c6> /System/Library/PrivateFrameworks/DataAccessExpress.framework/DataAccessExpress
0x34986000 - 0x3499bfff  DataDetectorsCore armv7s  <4c8d091a0b7f3260853ba0347236ee30> /System/Library/PrivateFrameworks/DataDetectorsCore.framework/DataDetectorsCore
0x3499d000 - 0x349b0fff  DataDetectorsUI armv7s  <1111beb447bb3fee9f49bed184793e2b> /System/Library/PrivateFrameworks/DataDetectorsUI.framework/DataDetectorsUI
0x349b1000 - 0x349b2fff  DataMigration armv7s  <5e7169ad01853bd0ba0f66648a67a010> /System/Library/PrivateFrameworks/DataMigration.framework/DataMigration
0x349b5000 - 0x349cefff  DictionaryServices armv7s  <27298e235f2c35938e1033517b1196a7> /System/Library/PrivateFrameworks/DictionaryServices.framework/DictionaryServices
0x349d6000 - 0x349eefff  EAP8021X armv7s  <25f0f325ef0c3c6f987b75b0bb6d1dd1> /System/Library/PrivateFrameworks/EAP8021X.framework/EAP8021X
0x34a02000 - 0x34a40fff  FTServices armv7s  <71ca9253aee730eca6c4ca3210861a2c> /System/Library/PrivateFrameworks/FTServices.framework/FTServices
0x34a41000 - 0x34e54fff  FaceCoreLight armv7s  <432cbaeb84743441b9286532bc36c96d> /System/Library/PrivateFrameworks/FaceCoreLight.framework/FaceCoreLight
0x34ea1000 - 0x34ea6fff  libGPUSupportMercury.dylib armv7s  <64ed3952bc683fef8a42a60ad7bf3f8c> /System/Library/PrivateFrameworks/GPUSupport.framework/libGPUSupportMercury.dylib
0x3504c000 - 0x35058fff  GenerationalStorage armv7s  <4e1afa8de682332ba6a042a6000c636e> /System/Library/PrivateFrameworks/GenerationalStorage.framework/GenerationalStorage
0x35059000 - 0x35152fff  GeoServices armv7s  <12d1626ed0f733d7bacca40380622f99> /System/Library/PrivateFrameworks/GeoServices.framework/GeoServices
0x35153000 - 0x3515efff  GraphicsServices armv7s  <44b33c403523309c9e930818c7fced34> /System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices
0x351cd000 - 0x35248fff  HomeSharing armv7s  <137c1fbc6a843d369038348255635111> /System/Library/PrivateFrameworks/HomeSharing.framework/HomeSharing
0x35249000 - 0x35253fff  IAP armv7s  <f43af100e43c3d1fac19a86cb7665c18> /System/Library/PrivateFrameworks/IAP.framework/IAP
0x352a1000 - 0x3530afff  IMAVCore armv7s  <78a21c381d173ce6b17cee820dd2dbf7> /System/Library/PrivateFrameworks/IMAVCore.framework/IMAVCore
0x3530b000 - 0x35383fff  IMCore armv7s  <a212f1303a4f3d47aaf21078f172e4bf> /System/Library/PrivateFrameworks/IMCore.framework/IMCore
0x3544a000 - 0x35496fff  IMFoundation armv7s  <55151f53b10934c3a5faac54e354f3f1> /System/Library/PrivateFrameworks/IMFoundation.framework/IMFoundation
0x3549d000 - 0x3549efff  IOAccelerator armv7s  <832913083f7f347fba1340263ff13b52> /System/Library/PrivateFrameworks/IOAccelerator.framework/IOAccelerator
0x3549f000 - 0x354a4fff  IOMobileFramebuffer armv7s  <828a36a2325738bb8f2d4b97730d253a> /System/Library/PrivateFrameworks/IOMobileFramebuffer.framework/IOMobileFramebuffer
0x354a5000 - 0x354a9fff  IOSurface armv7s  <9925fbc4a08d3a17b72ac807cbbba8ba> /System/Library/PrivateFrameworks/IOSurface.framework/IOSurface
0x354ee000 - 0x354f2fff  IncomingCallFilter armv7s  <8624065e862b3cc7b03b6635181ce2cf> /System/Library/PrivateFrameworks/IncomingCallFilter.framework/IncomingCallFilter
0x354f3000 - 0x3569afff  JavaScriptCore armv7s  <f7be721eee903a93a7de361e5627445e> /System/Library/PrivateFrameworks/JavaScriptCore.framework/JavaScriptCore
0x35766000 - 0x357befff  ManagedConfiguration armv7s  <b147c2d6f0283d988099706a2a404280> /System/Library/PrivateFrameworks/ManagedConfiguration.framework/ManagedConfiguration
0x357bf000 - 0x357c4fff  Marco armv7s  <53ab26b3197135a781d55819fd80f032> /System/Library/PrivateFrameworks/Marco.framework/Marco
0x357d5000 - 0x3584bfff  MediaControlSender armv7s  <29ff7ec2b02d36ec8bf6db33c3a4ba8e> /System/Library/PrivateFrameworks/MediaControlSender.framework/MediaControlSender
0x3584c000 - 0x35855fff  MediaRemote armv7s  <0dc7c7c324d33af8b2f7d57f41123de9> /System/Library/PrivateFrameworks/MediaRemote.framework/MediaRemote
0x35995000 - 0x359c2fff  MobileAsset armv7s  <e3217ead58d5390395de360b3ca3a10a> /System/Library/PrivateFrameworks/MobileAsset.framework/MobileAsset
0x35a07000 - 0x35a0afff  MobileInstallation armv7s  <7cbe167946123bbea56ae58208e09762> /System/Library/PrivateFrameworks/MobileInstallation.framework/MobileInstallation
0x35a0b000 - 0x35a11fff  MobileKeyBag armv7s  <5c7d50e11eb537ae89ea12cb7ddd3935> /System/Library/PrivateFrameworks/MobileKeyBag.framework/MobileKeyBag
0x35a6e000 - 0x35a71fff  MobileSystemServices armv7s  <5796fff2895f38e4b0f844269d4fbae5> /System/Library/PrivateFrameworks/MobileSystemServices.framework/MobileSystemServices
0x35a89000 - 0x35a92fff  MobileWiFi armv7s  <e9ae11c07476390d9598c861658cee7d> /System/Library/PrivateFrameworks/MobileWiFi.framework/MobileWiFi
0x35aac000 - 0x35bf0fff  MusicLibrary armv7s  <057b076c74fd31b590bccc9b64d7f5cb> /System/Library/PrivateFrameworks/MusicLibrary.framework/MusicLibrary
0x35c22000 - 0x35c24fff  OAuth armv7s  <8e91174312e43ca9ac07d91d16b32d15> /System/Library/PrivateFrameworks/OAuth.framework/OAuth
0x36349000 - 0x3636dfff  OpenCL armv7s  <9fb5ca4c594c3ae8baf7e0b0c299733b> /System/Library/PrivateFrameworks/OpenCL.framework/OpenCL
0x366cf000 - 0x366ecfff  PersistentConnection armv7s  <c5164e016fa6340fbce9251278385105> /System/Library/PrivateFrameworks/PersistentConnection.framework/PersistentConnection
0x36982000 - 0x369aafff  PrintKit armv7s  <7109f645a9ca3a4997b4172aed228723> /System/Library/PrivateFrameworks/PrintKit.framework/PrintKit
0x369ab000 - 0x36a1ffff  ProofReader armv7s  <e391e8d141c5352d978e5fde23afaaad> /System/Library/PrivateFrameworks/ProofReader.framework/ProofReader
0x36a20000 - 0x36a28fff  ProtocolBuffer armv7s  <edc3f72bf38c3d81954ac85f489a17e8> /System/Library/PrivateFrameworks/ProtocolBuffer.framework/ProtocolBuffer
0x36a45000 - 0x36a9dfff  SAObjects armv7s  <d0a0ae2eeca234bc807c4f66896a4022> /System/Library/PrivateFrameworks/SAObjects.framework/SAObjects
0x36b64000 - 0x36b75fff  SpringBoardServices armv7s  <bb92c069669b36959d3e82d4144f4264> /System/Library/PrivateFrameworks/SpringBoardServices.framework/SpringBoardServices
0x36bd7000 - 0x36cb2fff  StoreServices armv7s  <e465f24460ff3764b4fc95ebd44b2fe3> /System/Library/PrivateFrameworks/StoreServices.framework/StoreServices
0x36d00000 - 0x36d02fff  TCC armv7s  <95c2aa492cc03862bd7bbfae6fa62b1b> /System/Library/PrivateFrameworks/TCC.framework/TCC
0x36d21000 - 0x36d2efff  TelephonyUtilities armv7s  <aa759d908b903f978ab6803b7947e524> /System/Library/PrivateFrameworks/TelephonyUtilities.framework/TelephonyUtilities
0x36d2f000 - 0x37155fff  TextInput armv7s  <42f00d191694378fb1343b6d3c15e022> /System/Library/PrivateFrameworks/TextInput.framework/TextInput
0x371b3000 - 0x37253fff  UIFoundation armv7s  <e3a40cee28653c4485a4918016ff2b8e> /System/Library/PrivateFrameworks/UIFoundation.framework/UIFoundation
0x3752a000 - 0x37540fff  VoiceServices armv7s  <f00d5d73bf3f3acfb7d0b1b0447f071b> /System/Library/PrivateFrameworks/VoiceServices.framework/VoiceServices
0x37557000 - 0x37576fff  WebBookmarks armv7s  <ab55332c13da33fd825ea6204338fe19> /System/Library/PrivateFrameworks/WebBookmarks.framework/WebBookmarks
0x37577000 - 0x37ea7fff  WebCore armv7s  <b87e1ce4e58231108043c9ae79bb01d4> /System/Library/PrivateFrameworks/WebCore.framework/WebCore
0x37ea8000 - 0x37f84fff  WebKit armv7s  <6bd57205f7a43f6eb49f3037b57cc5f6> /System/Library/PrivateFrameworks/WebKit.framework/WebKit
0x3802f000 - 0x38036fff  XPCObjects armv7s  <e6846a96a21d382f9fffd6a4536c0aa7> /System/Library/PrivateFrameworks/XPCObjects.framework/XPCObjects
0x382db000 - 0x38313fff  iTunesStore armv7s  <10c8c7e5c9f43f75af5b30fc2389c1a2> /System/Library/PrivateFrameworks/iTunesStore.framework/iTunesStore
0x38ba1000 - 0x38ba7fff  libAccessibility.dylib armv7s  <9111bc894a4f3ef683f5ef4d699a861b> /usr/lib/libAccessibility.dylib
0x38ba8000 - 0x38bbefff  libCRFSuite.dylib armv7s  <770ebb2f7d9a35749e6da5d1980c244f> /usr/lib/libCRFSuite.dylib
0x38bd6000 - 0x38be2fff  libMobileGestalt.dylib armv7s  <7cf3ae0983a830d1a5dc91edb216b3f8> /usr/lib/libMobileGestalt.dylib
0x38bf4000 - 0x38bf4fff  libSystem.B.dylib armv7s  <12daef214fd234158028c97c22dc5cca> /usr/lib/libSystem.B.dylib
0x38d16000 - 0x38d22fff  libbsm.0.dylib armv7s  <0f4a8d65b05a364abca1a97e2ae72cb5> /usr/lib/libbsm.0.dylib
0x38d23000 - 0x38d2cfff  libbz2.1.0.dylib armv7s  <f54b70863d9c3751bb59253b1cb4c706> /usr/lib/libbz2.1.0.dylib
0x38d2d000 - 0x38d78fff  libc++.1.dylib armv7s  <3beff5a5233b3f51ab2fc748b68e9519> /usr/lib/libc++.1.dylib
0x38d79000 - 0x38d8cfff  libc++abi.dylib armv7s  <f47a5c7bc24c3e4fa73f11b61af635da> /usr/lib/libc++abi.dylib
0x38dbd000 - 0x38eaafff  libiconv.2.dylib armv7s  <81d6972465103fa3b85b4125f0ad33f1> /usr/lib/libiconv.2.dylib
0x38eab000 - 0x38ff4fff  libicucore.A.dylib armv7s  <642482cfc34a3a3b97bd731258dcdc6a> /usr/lib/libicucore.A.dylib
0x38ffc000 - 0x38ffcfff  liblangid.dylib armv7s  <ffb53baa33ba3642a55737311f17a672> /usr/lib/liblangid.dylib
0x38fff000 - 0x39006fff  liblockdown.dylib armv7s  <d484b93ed83c3b0bb5c6721134662453> /usr/lib/liblockdown.dylib
0x39039000 - 0x39142fff  libmecab_em.dylib armv7s  <1c4b0af073683641b5ccda10867a6a1c> /usr/lib/libmecab_em.dylib
0x39143000 - 0x392e6fff  libmecabra.dylib armv7s  <3b39df1d195d3feaa9c268fcedd3a2f8> /usr/lib/libmecabra.dylib
0x392e7000 - 0x392fcfff  libmis.dylib armv7s  <8f0712b99e8e3f5e998f0240f75bb5ba> /usr/lib/libmis.dylib
0x39325000 - 0x39423fff  libobjc.A.dylib armv7s  <1d499765d38c3c8fa92b363f529a02dd> /usr/lib/libobjc.A.dylib
0x394e7000 - 0x394fcfff  libresolv.9.dylib armv7s  <3f7be9d397d63b8e931d21bd5f49b0eb> /usr/lib/libresolv.9.dylib
0x39521000 - 0x395a7fff  libsqlite3.dylib armv7s  <758898189dca32a5a19e5200b8952110> /usr/lib/libsqlite3.dylib
0x395a8000 - 0x395f4fff  libstdc++.6.dylib armv7s  <249e8ca1717b370287bb556bbd96e303> /usr/lib/libstdc++.6.dylib
0x395f5000 - 0x3961bfff  libtidy.A.dylib armv7s  <96b463f0ffa0344699fce4d48aa623bc> /usr/lib/libtidy.A.dylib
0x3961f000 - 0x396ccfff  libxml2.2.dylib armv7s  <e87724e212573773a60bc56815cec706> /usr/lib/libxml2.2.dylib
0x396cd000 - 0x396edfff  libxslt.1.dylib armv7s  <c52fbe01ce7b35c799630e97e8f1318b> /usr/lib/libxslt.1.dylib
0x396ee000 - 0x396fafff  libz.1.dylib armv7s  <b64a5c1989ba3ba4aafae83d841f9496> /usr/lib/libz.1.dylib
0x396fb000 - 0x396fefff  libcache.dylib armv7s  <911ce99a94623ef1ae1ea786055fd558> /usr/lib/system/libcache.dylib
0x396ff000 - 0x39705fff  libcommonCrypto.dylib armv7s  <33140a5fa3fb3e5e8c6bb19bc0e21c5c> /usr/lib/system/libcommonCrypto.dylib
0x39706000 - 0x39708fff  libcompiler_rt.dylib armv7s  <cd17f0ee3dbc38f99910d12a6056bf5a> /usr/lib/system/libcompiler_rt.dylib
0x39709000 - 0x3970efff  libcopyfile.dylib armv7s  <5e733170766430eeaa4e7784e3c7555c> /usr/lib/system/libcopyfile.dylib
0x3970f000 - 0x39745fff  libcorecrypto.dylib armv7s  <a15c807dcb003ad69810546a578774d9> /usr/lib/system/libcorecrypto.dylib
0x39746000 - 0x39756fff  libdispatch.dylib armv7s  <247a388103633e17b24be038eac612c0> /usr/lib/system/libdispatch.dylib
0x39757000 - 0x39758fff  libdnsinfo.dylib armv7s  <f873dd712561350096b9452bf1fc4078> /usr/lib/system/libdnsinfo.dylib
0x39759000 - 0x3975afff  libdyld.dylib armv7s  <d8d1e76c619b3a7cacfc4dc30a50d9bc> /usr/lib/system/libdyld.dylib
0x3975b000 - 0x3975bfff  libkeymgr.dylib armv7s  <b0a1a911d4853feba44133e9ce499bc9> /usr/lib/system/libkeymgr.dylib
0x3975c000 - 0x39761fff  liblaunch.dylib armv7s  <69dd64aba1413e75967cd4ad0afa2c15> /usr/lib/system/liblaunch.dylib
0x39762000 - 0x39765fff  libmacho.dylib armv7s  <5905b311c6fb376388e56a991bb3193d> /usr/lib/system/libmacho.dylib
0x39766000 - 0x39767fff  libremovefile.dylib armv7s  <b40e964d7c563296b38625bc7082d6a8> /usr/lib/system/libremovefile.dylib
0x39768000 - 0x39768fff  libsystem_blocks.dylib armv7s  <77a9976b82b73796a0bbc9783929a1e7> /usr/lib/system/libsystem_blocks.dylib
0x39769000 - 0x397effff  libsystem_c.dylib armv7s  <11bcf1060ec63c8b909a452e6f79be08> /usr/lib/system/libsystem_c.dylib
0x397f0000 - 0x397f6fff  libsystem_dnssd.dylib armv7s  <94fab309ed9b35cdbc075cdda221bc70> /usr/lib/system/libsystem_dnssd.dylib
0x397f7000 - 0x3980ffff  libsystem_info.dylib armv7s  <195d8eeb7c3f31bd916c0b5611abc0e7> /usr/lib/system/libsystem_info.dylib
0x39810000 - 0x39826fff  libsystem_kernel.dylib armv7s  <a6afa72d4ec335d79b63aa47114cc24a> /usr/lib/system/libsystem_kernel.dylib
0x39827000 - 0x39843fff  libsystem_m.dylib armv7s  <faafc8292d4935c4a78233e1d0879e13> /usr/lib/system/libsystem_m.dylib
0x39844000 - 0x39852fff  libsystem_network.dylib armv7s  <137f48e279a83d7496659c8e3d3729d4> /usr/lib/system/libsystem_network.dylib
0x39853000 - 0x3985afff  libsystem_notify.dylib armv7s  <df14146497cb3fa0a002eedbed49da65> /usr/lib/system/libsystem_notify.dylib
0x3985b000 - 0x3985cfff  libsystem_sandbox.dylib armv7s  <85e91e99abc03db88eddc665424090b4> /usr/lib/system/libsystem_sandbox.dylib
0x3985d000 - 0x3985dfff  libunwind.dylib armv7s  <3b7ec561dbec3a199f09ea08a64e76ee> /usr/lib/system/libunwind.dylib
0x3985e000 - 0x39873fff  libxpc.dylib armv7s  <0562a59bdf8d3f7783e93f35d7e724a8> /usr/lib/system/libxpc.dylib
```
