### PR TITLE
認証していなくても username が返る

### DIFF
--- a/SDK/UI/Model/HTBUserManager.m
+++ b/SDK/UI/Model/HTBUserManager.m
@@ -43,6 +43,7 @@
 {
     [self setTokenKey:nil];
     [self setTokenSecret:nil];
+    [self setAuthorizeEntry:nil];
 }
 
 - (void)setToken:(AFOAuth1Token *)token


### PR DESCRIPTION
先日追加された sharedManager.username ですが、ログインしていない場合でもユーザー名が返るようです。

NSUserDefaults の中身を logout した際に消していない?
認証済みでない場合は nil が返るのが望ましい挙動かなと思います。
