### PR TITLE
Suppress warning message when present login view doubly.

### DIFF
--- a/DemoApp/DemoApp/HTBDemoViewController.m
+++ b/DemoApp/DemoApp/HTBDemoViewController.m
@@ -40,9 +40,7 @@
 
     [self initializeHatenaBookmarkClient];
     [self toggleLoginButtons];
-
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(showOAuthLoginView:) name:kHTBLoginStartNotification object:nil];
-
+    
     [self loadHatenaBookmark];
 }
 
@@ -89,6 +87,8 @@
 }
 
 -(void)showOAuthLoginView:(NSNotification *)notification {
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:kHTBLoginStartNotification object:nil];
+    
     NSURLRequest *req = (NSURLRequest *)notification.object;
     UINavigationController *navigationController = [[UINavigationController alloc] initWithNavigationBarClass:[HTBNavigationBar class] toolbarClass:nil];
     HTBLoginWebViewController *viewController = [[HTBLoginWebViewController alloc] initWithAuthorizationRequest:req];
@@ -98,10 +98,11 @@
 
 - (IBAction)loginButtonPushed:(id)sender
 {
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(showOAuthLoginView:) name:kHTBLoginStartNotification object:nil];
+    
     [[HTBHatenaBookmarkManager sharedManager] logout];
     [[HTBHatenaBookmarkManager sharedManager] authorizeWithSuccess:^{
         [self toggleLoginButtons];
-//        self.navigationItem.rightBarButtonItem.enabled = [HTBHatenaBookmarkManager sharedManager].authorized;
     } failure:^(NSError *error) {
     }];
 }


### PR DESCRIPTION
未ログインの状態で`HTBHateanBookmarkViewController`を表示したとき、ログイン画面を表示することができるようになりましたが、デモアプリではそのタイミングで`HTBDemoViewController`の`kHTBLoginStartNotification`の通知が発動して、そちらでもログイン画面を表示しようとして、結果的に2重にログイン画面を表示することになり、下記のようなWarning messageが出力されていました。

```
Warning: Attempt to present <UINavigationController: 0x8bc7560>  on <UINavigationController: 0x727c7e0> which is already presenting <UIActivityViewController: 0x8a8c160>
```

デモアプリにおいて、`kHTBLoginStartNotification`の通知はログインしようとする直前に登録、ログイン画面を表示したら解除するように変更しました。
