### PR TITLE
UIActivityViewControllerが消えない

### DIFF
--- a/DemoApp/DemoApp.xcodeproj/project.pbxproj
+++ b/DemoApp/DemoApp.xcodeproj/project.pbxproj
@@ -440,7 +440,7 @@
 				ORGANIZATIONNAME = "Hatena Co., Ltd.";
 				TargetAttributes = {
 					267CCBFC178A5D3900063953 = {
-						TestTargetID = 267CCBDB178A5D3900063953;
+						TestTargetID = 267CCBDB178A5D3900063953 /* DemoApp */;
 					};
 				};
 			};

--- a/SDK/UI/HTBHatenaBookmarkActivity.m
+++ b/SDK/UI/HTBHatenaBookmarkActivity.m
@@ -58,7 +58,7 @@
             NSString *scheme = [(NSURL *)activityItem scheme];
             if ([scheme isEqualToString:@"http"] || [scheme isEqualToString:@"https"]) {
                 url = activityItem;
-            }            
+            }
         }
     }
 }
@@ -66,6 +66,9 @@
 - (UIViewController *)activityViewController {
     HTBHatenaBookmarkViewController *viewController = [[HTBHatenaBookmarkViewController alloc] init];
     viewController.URL = url;
+    viewController.completionHandler = ^(BOOL completion) {
+        [self activityDidFinish:completion];
+    };
     return viewController;
 }
 

--- a/SDK/UI/ViewController/HTBBookmarkViewController.m
+++ b/SDK/UI/ViewController/HTBBookmarkViewController.m
@@ -41,6 +41,7 @@
 #import "HTBCanonicalEntry.h"
 #import "HTBCanonicalView.h"
 #import "UIAlertView+HTBNSError.h"
+#import "HTBHatenaBookmarkViewController.h"
 
 @interface HTBBookmarkViewController ()
 @property (nonatomic, strong) HTBBookmarkEntry *entry;
@@ -176,11 +177,6 @@
 -(void)viewWillAppear:(BOOL)animated
 {
     [super viewWillAppear:animated];
-}
-
--(void)viewDidAppear:(BOOL)animated
-{
-    [super viewDidAppear:animated];
     [self.rootView.commentTextView becomeFirstResponder];
 }
 
@@ -245,7 +241,7 @@
     [[HTBHatenaBookmarkManager sharedManager] postBookmarkWithURL:self.URL comment:self.rootView.commentTextView.text tags:tags options:options success:^(HTBBookmarkedDataEntry *entry) {
         [self setBookmarkedDataEntry:entry];
         [self.rootView.myBookmarkActivityIndicatorView stopAnimating];
-        [self dismissViewControllerAnimated:YES completion:nil];
+        [self dismissHatenaBookmarkViewControllerCompleted:YES];
     } failure:^(NSError *error) {
         [self handleHTTPError:error];
         [self.rootView.myBookmarkActivityIndicatorView stopAnimating];
@@ -261,7 +257,7 @@
         UIBarButtonItem *addButton = [[UIBarButtonItem alloc] initWithTitle:[HTBUtility localizedStringForKey:@"add" withDefault:@"Add"] style:UIBarButtonItemStyleBordered target:self action:@selector(addBookmarkButtonPushed:)];
         self.navigationItem.rightBarButtonItems = @[addButton];
         [self.rootView.myBookmarkActivityIndicatorView stopAnimating];
-        [self dismissViewControllerAnimated:YES completion:nil];
+        [self dismissHatenaBookmarkViewControllerCompleted:YES];
     } failure:^(NSError *error) {
         [self handleHTTPError:error];
         [self.rootView.myBookmarkActivityIndicatorView stopAnimating];
@@ -276,7 +272,7 @@
 - (void)dismiss
 {
     [self.rootView.commentTextView resignFirstResponder];
-    [self dismissViewControllerAnimated:YES completion:nil];
+    [self dismissHatenaBookmarkViewControllerCompleted:NO];
 }
 
 - (void)reloadEntity
@@ -328,6 +324,17 @@
     } failure:^(NSError *error) {
         [self handleHTTPError:error];
     }];
+}
+
+
+- (void)dismissHatenaBookmarkViewControllerCompleted:(BOOL)completed {
+    HTBHatenaBookmarkViewController *hatenaBookmarkViewController = self.navigationController.parentViewController;
+    if (hatenaBookmarkViewController.completionHandler) {
+        hatenaBookmarkViewController.completionHandler(completed);
+    }
+    if (!hatenaBookmarkViewController.isBeingDismissed) {
+        [self dismissViewControllerAnimated:YES completion:nil];
+    }
 }
 
 @end

--- a/SDK/UI/ViewController/HTBHatenaBookmarkViewController.h
+++ b/SDK/UI/ViewController/HTBHatenaBookmarkViewController.h
@@ -24,4 +24,5 @@
 
 @interface HTBHatenaBookmarkViewController : UIViewController<UIAlertViewDelegate>
 @property (nonatomic, strong) NSURL *URL;
+@property (nonatomic, copy) void (^completionHandler)(BOOL completed);
 @end


### PR DESCRIPTION
via @0x0c https://github.com/hatena/Hatena-Bookmark-iOS-SDK/pull/11

> UIActivityViewControllerからHTBHatenaBookmarkViewControllerを表示し、Cancelで> 投稿せずにdismissした際に戻ってきた画面にUIActivityViewControllerが表示されたままになっております。
> 戻ってきた画面では、UIActivityViewControllerが表示されないようにしたほうが動作が自然と思いました。

操作を間違えて別のbranchと紐付けてしまったので、一旦closeしてIssueを立て直しました
