### PR TITLE
HTBCanonicalViewの背景画像が横画面だと伸びて表示される

### DIFF
--- a/SDK/UI/View/HTBCanonicalView.m
+++ b/SDK/UI/View/HTBCanonicalView.m
@@ -70,7 +70,7 @@
     [self addSubview:_disclosureIndicatorImageView];
 
     NSString *resourcePath = [[HTBUtility hatenaBookmarkSDKBundle] resourcePath];
-    [self setBackgroundImage:[UIImage imageWithContentsOfFile:[resourcePath stringByAppendingPathComponent:@"Images/canonical.png"]] forState:UIControlStateNormal];
+    [self setBackgroundImage:[[UIImage imageWithContentsOfFile:[resourcePath stringByAppendingPathComponent:@"Images/canonical.png"]] resizableImageWithCapInsets:UIEdgeInsetsMake(8, 8, 8, 8)] forState:UIControlStateNormal];
 }
 
 - (void)setHighlighted: (BOOL) highlighted {


### PR DESCRIPTION
`canonical.png`がタテのサイズに対応したものしかないので少し伸びて表示されてしまいます。
カドのところを見るとわかりやすいです。

![ios 2013 08 27 3 04 59](https://f.cloud.github.com/assets/40610/1027888/17f20d08-0e7a-11e3-893b-67b6ac539d21.png)
