### PR TITLE
idが長いと[削除]ボタンが表示されない

### DIFF
--- a/SDK/UI/ViewController/HTBBookmarkViewController.m
+++ b/SDK/UI/ViewController/HTBBookmarkViewController.m
@@ -82,16 +82,24 @@
 
     if ([HTBHatenaBookmarkManager sharedManager].authorized) {
         UIButton *logoutButton = [UIButton buttonWithType:UIButtonTypeCustom];
+        UIView *wrapper =[[UIView alloc] initWithFrame:CGRectMake(0, 0, 120, 45)];
         logoutButton.frame = CGRectMake(0, 0, 120, 45);
         logoutButton.showsTouchWhenHighlighted = YES;
         logoutButton.titleLabel.font = [UIFont boldSystemFontOfSize:17];
         logoutButton.titleLabel.numberOfLines = 1;
-        logoutButton.titleLabel.lineBreakMode = UILineBreakModeClip;
-        logoutButton.titleLabel.minimumFontSize = 1;
+        if ([logoutButton.titleLabel respondsToSelector:@selector(setMinimumScaleFactor:)]) { // iOS6 or later.
+            logoutButton.titleLabel.lineBreakMode = NSLineBreakByTruncatingTail;
+            logoutButton.titleLabel.minimumScaleFactor = 10.f / 17.f;
+        } else {
+            logoutButton.titleLabel.lineBreakMode = UILineBreakModeClip;
+            logoutButton.titleLabel.minimumFontSize = 10;
+        }
         logoutButton.titleLabel.adjustsFontSizeToFitWidth = YES;
+        logoutButton.titleLabel.adjustsLetterSpacingToFitWidth = YES;
         [logoutButton setTitle:[NSString stringWithFormat:@"id:%@", [HTBHatenaBookmarkManager sharedManager].username] forState:UIControlStateNormal];
         [logoutButton addTarget:self action:@selector(logoutButtonPushed:) forControlEvents:UIControlEventTouchUpInside];
-        self.navigationItem.titleView = logoutButton;
+        [wrapper addSubview:logoutButton];
+        self.navigationItem.titleView = wrapper;
     }
 }
 


### PR DESCRIPTION
https://github.com/hatena/Hatena-Bookmark-iOS-SDK/commit/c53bb18e8038f22dbd08aef67d39ea972e438669

↑ こちらのログアウトボタンの変更の影響と思うのですが、titileViewにボタンが入るようになり、その幅が長い場合に削除ボタンが表示されなくなります。

![screenshot 2013 08 26 19 30 44](https://f.cloud.github.com/assets/40610/1025123/0d833f16-0e3b-11e3-9384-ada7c192195d.png)
