### PR TITLE
iOS 5.xでコメントビューでメモリ不足の警告が起こった場合、編集中の内容が失われる

### DIFF
--- a/SDK/UI/View/HTBBookmarkToolbarView.h
+++ b/SDK/UI/View/HTBBookmarkToolbarView.h
@@ -37,4 +37,7 @@
 @property (nonatomic, strong) HTBToggleButton *evernoteToggleButton;
 @property (nonatomic, strong) HTBToggleButton *mailToggleButton;
 @property (nonatomic, strong) HTBToggleButton *privateToggleButton;
+
+@property (nonatomic, readonly, assign) HatenaBookmarkPOSTOptions selectedPostOptions;
+
 @end

--- a/SDK/UI/View/HTBBookmarkToolbarView.m
+++ b/SDK/UI/View/HTBBookmarkToolbarView.m
@@ -171,4 +171,26 @@
     }
 }
 
+- (HatenaBookmarkPOSTOptions)selectedPostOptions
+{
+    HatenaBookmarkPOSTOptions options = HatenaBookmarkPostOptionNone;
+
+    if (self.twitterToggleButton.selected) {
+        options |= HatenaBookmarkPostOptionTwitter;
+    }
+    if (self.facebookToggleButton.selected) {
+        options |= HatenaBookmarkPostOptionFacebook;
+    }
+    if (self.mixiToggleButton.selected) {
+        options |= HatenaBookmarkPostOptionMixi;
+    }
+    if (self.mailToggleButton.selected) {
+        options |= HatenaBookmarkPostOptionSendMail;
+    }
+    if (self.evernoteToggleButton.selected) {
+        options |= HatenaBookmarkPostOptionEvernote;
+    }
+    return options;
+}
+
 @end


### PR DESCRIPTION
ブックマークビューからコメントビューに移動した後、そこでメモリ不足の警告が起こると、ブックマークビューのビューがアンロードされるので、入力途中のテキストが失われる。

iOS 6〜は`viewDidUnload`が呼ばれないので問題ない。
