### PR TITLE
ドキュメント改善: Without CocoaPods

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ pod 'HatenaBookmarkSDK'
 
 ## Without CocoaPods
 
+Clone this repository.
+
+```
+git clone --recursive https://github.com/hatena/Hatena-Bookmark-iOS-SDK.git
+```
+
 Copy `/SDK/` directory and add dependent modules [AFNetworking](https://github.com/AFNetworking/AFNetworking) and [SFHFKeychainUtils](https://github.com/ldandersen/scifihifi-iphone/) to your project .
 
 # Usage


### PR DESCRIPTION
非CocoaPodsユーザー向けに

> ricenoodles-
> そのままプロジェクトをビルドしようとするとHatenaBookmarkSDK以下のSFHFKeychainUtilsとAFNetworkingが無いって言われる。GitHubで落とさないとだめっぽい。-
> http://b.hatena.ne.jp/ricenoodles/20130830#bookmark-159565494

必要なモジュールはgit-submodule化しているのでGithubチームのリポジトリのように script/bootstrap をチェックアウト後に実行するスタイルがいいかと思います。
https://github.com/github/Archimedes/blob/master/script/bootstrap (https://github.com/github/ )
