### PR TITLE
不正なconsumer key/secretを設定している場合にわかるような仕組みが欲しい

### DIFF
--- a/DemoApp/DemoApp/HTBDemoViewController.m
+++ b/DemoApp/DemoApp/HTBDemoViewController.m
@@ -115,6 +115,8 @@
     [[HTBHatenaBookmarkManager sharedManager] authorizeWithSuccess:^{
         [self toggleLoginButtons];
     } failure:^(NSError *error) {
+        UIAlertView* errorAlert = [[UIAlertView alloc] initWithTitle:error.localizedDescription message:error.localizedRecoverySuggestion delegate:nil cancelButtonTitle:NSLocalizedString(@"Close", nil) otherButtonTitles:nil];
+        [errorAlert show];
     }];
 }
 


### PR DESCRIPTION
たとえばDemoAppのconsumer keyを書き換えずにアプリ起動すると

・左下 Login ボタンが反応しない
・HTBLoginWebViewControllerの画面が白紙

という現象が起きます(何回か気づかずに遭遇していました)。

DemoApp内のエラー表示は開発者向けなのでこんな感じでよいかなと思ったのですが
![](http://gyazo.com/70b2bddf5897e2b178678b09f27a37e6.png)

SDK設計レベルでも
https://github.com/hatena/Hatena-Bookmark-iOS-SDK/blob/master/SDK/UI/ViewController/HTBLoginWebViewController.m#L49

このあたりで何かしらエラー処理が必要かと思われます。
