### PR TITLE
Fix iOS 7 UITextView scrolling bug.

### DIFF
--- a/SDK/UI/View/HTBPlaceholderTextView.m
+++ b/SDK/UI/View/HTBPlaceholderTextView.m
@@ -114,4 +114,64 @@
     [super drawRect:rect];
 }
 
+- (CGRect)firstRectForRange:(UITextRange *)range
+{
+    if (floor(NSFoundationVersionNumber) > NSFoundationVersionNumber_iOS_6_1) {
+        CGRect r1= [self caretRectForPosition:[self positionWithinRange:range farthestInDirection:UITextLayoutDirectionRight]];
+        CGRect r2= [self caretRectForPosition:[self positionWithinRange:range farthestInDirection:UITextLayoutDirectionLeft]];
+        return CGRectUnion(r1,r2);
+    }
+    return [super firstRectForRange:range];
+}
+
+- (NSUInteger)characterIndexForPoint:(CGPoint)point
+{
+    if (self.text.length == 0) {
+        return 0;
+    }
+    
+    CGRect r1;
+    if ([[self.text substringFromIndex:self.text.length - 1] isEqualToString:@"\n"]) {
+        r1 = [super caretRectForPosition:[super positionFromPosition:self.endOfDocument offset:-1]];
+        CGRect sr = [super caretRectForPosition:[super positionFromPosition:self.beginningOfDocument offset:0]];
+        r1.origin.x = sr.origin.x;
+        r1.origin.y += self.font.lineHeight;
+    } else {
+        r1 = [super caretRectForPosition:[super positionFromPosition:self.endOfDocument offset:0]];
+    }
+    
+    if ((point.x > r1.origin.x && point.y >= r1.origin.y) || point.y >= r1.origin.y + r1.size.height) {
+        return [super offsetFromPosition:self.beginningOfDocument toPosition:self.endOfDocument];
+    }
+    
+    CGFloat fraction;
+    NSUInteger index = [self.textStorage.layoutManagers[0] characterIndexForPoint:point inTextContainer:self.textContainer fractionOfDistanceBetweenInsertionPoints:&fraction];
+    
+    return index;
+}
+
+- (UITextPosition *)closestPositionToPoint:(CGPoint)point
+{
+    if (floor(NSFoundationVersionNumber) > NSFoundationVersionNumber_iOS_6_1) {
+        point.y -= self.font.lineHeight / 2;
+        NSUInteger index = [self characterIndexForPoint:point];
+        UITextPosition *pos = [self positionFromPosition:self.beginningOfDocument offset:index];
+        return pos;
+    }
+    
+    return [super closestPositionToPoint:point];
+}
+
+- (void)scrollRangeToVisible:(NSRange)range
+{
+    [super scrollRangeToVisible:range];
+    
+    if (floor(NSFoundationVersionNumber) > NSFoundationVersionNumber_iOS_6_1) {
+        if (self.layoutManager.extraLineFragmentTextContainer != nil && self.selectedRange.location == range.location) {
+            CGRect caretRect = [self caretRectForPosition:self.selectedTextRange.end];
+            [self scrollRectToVisible:caretRect animated:NO];
+        }
+    }
+}
+
 @end


### PR DESCRIPTION
iOS 7のUITextViewの新しい行にスクロールしない、最初にフォーカスがあたった時にカーソル位置にスクロールしないなどの問題を修正するパッチです。

![ios 2013 11 20 2 32 56](https://f.cloud.github.com/assets/40610/1574680/006ec13e-5142-11e3-9ecc-c6010933c762.png)
