### PR TITLE
iOS5でログインできない不具合

### DIFF
--- a/SDK/UI/ViewController/HTBLoginWebViewController.m
+++ b/SDK/UI/ViewController/HTBLoginWebViewController.m
@@ -46,7 +46,9 @@
     if (self) {
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(loadOAuthLoginView:) name:kHTBLoginStartNotification object:nil];
         [[HTBHatenaBookmarkManager sharedManager] authorizeWithSuccess:^{
+            [self hideModalView:YES];
         } failure:^(NSError *error) {
+            [self hideModalView:NO];
         }];
     }
     
@@ -83,7 +85,7 @@
     if (queryString && [queryString rangeOfString:@"oauth_verifier"].location != NSNotFound) {
         NSNotification *notification = [NSNotification notificationWithName:kHTBLoginFinishNotification object:nil userInfo:@{ kHTBApplicationLaunchOptionsURLKey : request.URL }];
         [[NSNotificationCenter defaultCenter] postNotification:notification];
-        [self hideModalView:YES];
+
         return NO;
     }
     return YES;


### PR DESCRIPTION
"ログインが必要です"→HTBLoginWebViewControllerでログイン完了後に"ログインが必要です"のアラートが再度出現します。

HTBHatenaBookmarkViewControllerからHTBLoginWebViewControllerが呼び出された時に再現します。HTBLoginWebViewController単体で認証を終えてHTBHatenaBookmarkViewControllerを表示した場合には発生しません。

確認した限りではiOS6以上では発生しません。

ステップ実行して通信のタイミングがズレると発生しないこともありました。
HTBHatenaBookmarkManager共有ブジェクトのauthorizedフラグがYESになるタイミングの問題かなと予想しましたが、さだかではありません。

あと、この現象の影響を受けているのかAPIとの通信時にもエラーが出ていました。

通信ログ取りました。
HTBHatenaBookmarkViewControllerへ戻ってきた時に走るリクエストです

```
GET http://api.b.hatena.ne.jp/1/canonical_entry.json?url=http%3A%2F%2Fb.hatena.ne.jp%2Ftouch
   ← 200 application/json 91B
GET http://api.b.hatena.ne.jp/1/entry.json?url=http%3A%2F%2Fb.hatena.ne.jp%2Ftouch&with_tag_recommendations=1
   ← 400 text/plain 66B
GET http://api.b.hatena.ne.jp/1/my/bookmark.json?url=http%3A%2F%2Fb.hatena.ne.jp%2Ftouch
   ← 400 text/plain 66B
GET http://api.b.hatena.ne.jp/1/my/bookmark.json?url=http%3A%2F%2Fb.hatena.ne.jp%2Ftouch
   ← 401 text/plain 48B
GET http://api.b.hatena.ne.jp/1/my/tags.json
   ← 401 text/plain 48B
GET http://api.b.hatena.ne.jp/1/my.json
   ← 401 text/plain 48B
```

400の時は
    oauth_parameters_absent=oauth_token&oauth_problem=parameter_absent

401の時は
    oauth_problem=token_rejected

でした
