### PR TITLE
Changed placeholder instance name for conflict with Formotion

### DIFF
--- a/SDK/UI/View/HTBBookmarkRootView.m
+++ b/SDK/UI/View/HTBBookmarkRootView.m
@@ -110,7 +110,7 @@
     [self.bookmarkActivityIndicatorView startAnimating];
     [self.myBookmarkActivityIndicatorView startAnimating];
     self.commentTextView.font = [UIFont systemFontOfSize:17.f];
-    self.commentTextView.placeholder = [HTBUtility localizedStringForKey:@"add-comments" withDefault:@"Add comments"];
+    self.commentTextView.placeholderText = [HTBUtility localizedStringForKey:@"add-comments" withDefault:@"Add comments"];
     self.tagTextField.font = [UIFont systemFontOfSize:12.f];
     self.tagTextField.contentVerticalAlignment = UIControlContentVerticalAlignmentCenter;
 

--- a/SDK/UI/View/HTBPlaceholderTextView.h
+++ b/SDK/UI/View/HTBPlaceholderTextView.h
@@ -25,7 +25,7 @@
 
 @interface HTBPlaceholderTextView : UITextView
 
-@property (nonatomic, strong) NSString *placeholder;
+@property (nonatomic, strong) NSString *placeholderText;
 @property (nonatomic, strong) UIColor *placeholderColor;
 
 @end

--- a/SDK/UI/View/HTBPlaceholderTextView.m
+++ b/SDK/UI/View/HTBPlaceholderTextView.m
@@ -40,8 +40,8 @@
     
     // Use Interface Builder User Defined Runtime Attributes to set
     // placeholder and placeholderColor in Interface Builder.
-    if (!self.placeholder) {
-        [self setPlaceholder:@""];
+    if (!self.placeholderText) {
+        [self setPlaceholderText:@""];
     }
     
     if (!self.placeholderColor) {
@@ -55,7 +55,7 @@
 {
     if( (self = [super initWithFrame:frame]) )
     {
-        [self setPlaceholder:@""];
+        [self setPlaceholderText:@""];
         [self setPlaceholderColor:[UIColor lightGrayColor]];
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(textChanged:) name:UITextViewTextDidChangeNotification object:self];
     }
@@ -64,7 +64,7 @@
 
 - (void)textChanged:(NSNotification *)notification
 {
-    if([[self placeholder] length] == 0)
+    if([[self placeholderText] length] == 0)
     {
         return;
     }
@@ -86,7 +86,7 @@
 
 - (void)drawRect:(CGRect)rect
 {
-    if( [[self placeholder] length] > 0 )
+    if( [[self placeholderText] length] > 0 )
     {
         if (_placeHolderLabel == nil )
         {
@@ -101,12 +101,12 @@
             [self addSubview:_placeHolderLabel];
         }
         
-        _placeHolderLabel.text = self.placeholder;
+        _placeHolderLabel.text = self.placeholderText;
         [_placeHolderLabel sizeToFit];
         [self sendSubviewToBack:_placeHolderLabel];
     }
     
-    if( [[self text] length] == 0 && [[self placeholder] length] > 0 )
+    if( [[self text] length] == 0 && [[self placeholderText] length] > 0 )
     {
         [[self viewWithTag:999] setAlpha:1];
     }


### PR DESCRIPTION
# Problem

`placeholder` instance variable conflicts with Formotion's UITextView enhancement https://github.com/clayallsopp/formotion/blob/master/lib/formotion/patch/ui_text_view_placeholder.rb#L37. 
# Solution

This patch will change `HTBPlaceholderTextView` 's `placeholder` instance to `placeholderText`.
