### PR TITLE
AFNetworking 1.xを利用しているためにAFNetworking 2.xと共存できない問題の解消のためリネームしたAFNetworkingを同梱する

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "AFNetworking"]
-	path = AFNetworking
-	url = https://github.com/AFNetworking/AFNetworking.git
 [submodule "scifihifi-iphone"]
 	path = scifihifi-iphone
 	url = https://github.com/ldandersen/scifihifi-iphone.git

--- a/DemoApp/DemoApp.xcodeproj/project.pbxproj
+++ b/DemoApp/DemoApp.xcodeproj/project.pbxproj
@@ -8,6 +8,15 @@
 
 /* Begin PBXBuildFile section */
 		071C366017BE0478008EDF40 /* HTBAuthorizeEntry.m in Sources */ = {isa = PBXBuildFile; fileRef = 071C365F17BE0478008EDF40 /* HTBAuthorizeEntry.m */; };
+		099A4BDD18E028330085DD25 /* HatenaAFHTTPClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 099A4BCB18E028330085DD25 /* HatenaAFHTTPClient.m */; };
+		099A4BDE18E028330085DD25 /* HatenaAFHTTPRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 099A4BCD18E028330085DD25 /* HatenaAFHTTPRequestOperation.m */; };
+		099A4BDF18E028330085DD25 /* HatenaAFImageRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 099A4BCF18E028330085DD25 /* HatenaAFImageRequestOperation.m */; };
+		099A4BE018E028330085DD25 /* HatenaAFJSONRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 099A4BD118E028330085DD25 /* HatenaAFJSONRequestOperation.m */; };
+		099A4BE118E028330085DD25 /* HatenaAFNetworkActivityIndicatorManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 099A4BD318E028330085DD25 /* HatenaAFNetworkActivityIndicatorManager.m */; };
+		099A4BE218E028330085DD25 /* HatenaAFPropertyListRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 099A4BD618E028330085DD25 /* HatenaAFPropertyListRequestOperation.m */; };
+		099A4BE318E028330085DD25 /* HatenaAFURLConnectionOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 099A4BD818E028330085DD25 /* HatenaAFURLConnectionOperation.m */; };
+		099A4BE418E028330085DD25 /* HatenaAFXMLRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 099A4BDA18E028330085DD25 /* HatenaAFXMLRequestOperation.m */; };
+		099A4BE518E028330085DD25 /* UIImageView+HatenaAFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = 099A4BDC18E028330085DD25 /* UIImageView+HatenaAFNetworking.m */; };
 		260BE44D17AF1E2600BEA288 /* HTBHatenaBookmarkActivity.m in Sources */ = {isa = PBXBuildFile; fileRef = 260BE3E917AF1E2600BEA288 /* HTBHatenaBookmarkActivity.m */; };
 		260BE44F17AF1E2600BEA288 /* HTBBookmarkedDataEntry.m in Sources */ = {isa = PBXBuildFile; fileRef = 260BE3EE17AF1E2600BEA288 /* HTBBookmarkedDataEntry.m */; };
 		260BE45017AF1E2600BEA288 /* HTBBookmarkEntry.m in Sources */ = {isa = PBXBuildFile; fileRef = 260BE3F017AF1E2600BEA288 /* HTBBookmarkEntry.m */; };
@@ -50,15 +59,6 @@
 		26F6F1C017B0A7DB002475CF /* HTBAFOAuth1Client.m in Sources */ = {isa = PBXBuildFile; fileRef = 26F6F1BF17B0A7DB002475CF /* HTBAFOAuth1Client.m */; };
 		26F6F1C217B0BB44002475CF /* HTBResources.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 26F6F1C117B0BB43002475CF /* HTBResources.bundle */; };
 		26F6F1C717B0D48D002475CF /* SFHFKeychainUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 26F6F1C617B0D48D002475CF /* SFHFKeychainUtils.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		26F6F1DC17B0D4BC002475CF /* AFHTTPClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 26F6F1CA17B0D4BC002475CF /* AFHTTPClient.m */; };
-		26F6F1DD17B0D4BC002475CF /* AFHTTPRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 26F6F1CC17B0D4BC002475CF /* AFHTTPRequestOperation.m */; };
-		26F6F1DE17B0D4BC002475CF /* AFImageRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 26F6F1CE17B0D4BC002475CF /* AFImageRequestOperation.m */; };
-		26F6F1DF17B0D4BC002475CF /* AFJSONRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 26F6F1D017B0D4BC002475CF /* AFJSONRequestOperation.m */; };
-		26F6F1E017B0D4BC002475CF /* AFNetworkActivityIndicatorManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 26F6F1D217B0D4BC002475CF /* AFNetworkActivityIndicatorManager.m */; };
-		26F6F1E117B0D4BC002475CF /* AFPropertyListRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 26F6F1D517B0D4BC002475CF /* AFPropertyListRequestOperation.m */; };
-		26F6F1E217B0D4BC002475CF /* AFURLConnectionOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 26F6F1D717B0D4BC002475CF /* AFURLConnectionOperation.m */; };
-		26F6F1E317B0D4BC002475CF /* AFXMLRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 26F6F1D917B0D4BC002475CF /* AFXMLRequestOperation.m */; };
-		26F6F1E417B0D4BC002475CF /* UIImageView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = 26F6F1DB17B0D4BC002475CF /* UIImageView+AFNetworking.m */; };
 		26F6F1E617B0D549002475CF /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 26F6F1E517B0D549002475CF /* SystemConfiguration.framework */; };
 /* End PBXBuildFile section */
 
@@ -66,6 +66,25 @@
 		071808DF17D833E100384F1B /* HTBMacro.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HTBMacro.h; sourceTree = "<group>"; };
 		071C365E17BE0478008EDF40 /* HTBAuthorizeEntry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HTBAuthorizeEntry.h; sourceTree = "<group>"; };
 		071C365F17BE0478008EDF40 /* HTBAuthorizeEntry.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HTBAuthorizeEntry.m; sourceTree = "<group>"; };
+		099A4BCA18E028330085DD25 /* HatenaAFHTTPClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HatenaAFHTTPClient.h; sourceTree = "<group>"; };
+		099A4BCB18E028330085DD25 /* HatenaAFHTTPClient.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HatenaAFHTTPClient.m; sourceTree = "<group>"; };
+		099A4BCC18E028330085DD25 /* HatenaAFHTTPRequestOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HatenaAFHTTPRequestOperation.h; sourceTree = "<group>"; };
+		099A4BCD18E028330085DD25 /* HatenaAFHTTPRequestOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HatenaAFHTTPRequestOperation.m; sourceTree = "<group>"; };
+		099A4BCE18E028330085DD25 /* HatenaAFImageRequestOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HatenaAFImageRequestOperation.h; sourceTree = "<group>"; };
+		099A4BCF18E028330085DD25 /* HatenaAFImageRequestOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HatenaAFImageRequestOperation.m; sourceTree = "<group>"; };
+		099A4BD018E028330085DD25 /* HatenaAFJSONRequestOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HatenaAFJSONRequestOperation.h; sourceTree = "<group>"; };
+		099A4BD118E028330085DD25 /* HatenaAFJSONRequestOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HatenaAFJSONRequestOperation.m; sourceTree = "<group>"; };
+		099A4BD218E028330085DD25 /* HatenaAFNetworkActivityIndicatorManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HatenaAFNetworkActivityIndicatorManager.h; sourceTree = "<group>"; };
+		099A4BD318E028330085DD25 /* HatenaAFNetworkActivityIndicatorManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HatenaAFNetworkActivityIndicatorManager.m; sourceTree = "<group>"; };
+		099A4BD418E028330085DD25 /* HatenaAFNetworking.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HatenaAFNetworking.h; sourceTree = "<group>"; };
+		099A4BD518E028330085DD25 /* HatenaAFPropertyListRequestOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HatenaAFPropertyListRequestOperation.h; sourceTree = "<group>"; };
+		099A4BD618E028330085DD25 /* HatenaAFPropertyListRequestOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HatenaAFPropertyListRequestOperation.m; sourceTree = "<group>"; };
+		099A4BD718E028330085DD25 /* HatenaAFURLConnectionOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HatenaAFURLConnectionOperation.h; sourceTree = "<group>"; };
+		099A4BD818E028330085DD25 /* HatenaAFURLConnectionOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HatenaAFURLConnectionOperation.m; sourceTree = "<group>"; };
+		099A4BD918E028330085DD25 /* HatenaAFXMLRequestOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HatenaAFXMLRequestOperation.h; sourceTree = "<group>"; };
+		099A4BDA18E028330085DD25 /* HatenaAFXMLRequestOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HatenaAFXMLRequestOperation.m; sourceTree = "<group>"; };
+		099A4BDB18E028330085DD25 /* UIImageView+HatenaAFNetworking.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIImageView+HatenaAFNetworking.h"; sourceTree = "<group>"; };
+		099A4BDC18E028330085DD25 /* UIImageView+HatenaAFNetworking.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIImageView+HatenaAFNetworking.m"; sourceTree = "<group>"; };
 		260BE3E817AF1E2600BEA288 /* HTBHatenaBookmarkActivity.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HTBHatenaBookmarkActivity.h; sourceTree = "<group>"; };
 		260BE3E917AF1E2600BEA288 /* HTBHatenaBookmarkActivity.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HTBHatenaBookmarkActivity.m; sourceTree = "<group>"; };
 		260BE3ED17AF1E2600BEA288 /* HTBBookmarkedDataEntry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HTBBookmarkedDataEntry.h; sourceTree = "<group>"; };
@@ -137,33 +156,14 @@
 		269DCCCE17A644E900CDCDC0 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
 		26CA7E1117B0EED80091FF33 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
 		26F6F1BA17AF929E002475CF /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/InfoPlist.strings; sourceTree = "<group>"; };
-		26F6F1BB17B0A7D1002475CF /* HTBHatenaBookmarkAPIClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = HTBHatenaBookmarkAPIClient.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		26F6F1BC17B0A7D1002475CF /* HTBHatenaBookmarkAPIClient.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = HTBHatenaBookmarkAPIClient.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
+		26F6F1BB17B0A7D1002475CF /* HTBHatenaBookmarkAPIClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = HTBHatenaBookmarkAPIClient.h; sourceTree = "<group>"; };
+		26F6F1BC17B0A7D1002475CF /* HTBHatenaBookmarkAPIClient.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = HTBHatenaBookmarkAPIClient.m; sourceTree = "<group>"; };
 		26F6F1BE17B0A7DB002475CF /* HTBAFOAuth1Client.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HTBAFOAuth1Client.h; sourceTree = "<group>"; };
 		26F6F1BF17B0A7DB002475CF /* HTBAFOAuth1Client.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = HTBAFOAuth1Client.m; sourceTree = "<group>"; };
 		26F6F1C117B0BB43002475CF /* HTBResources.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = HTBResources.bundle; sourceTree = "<group>"; };
 		26F6F1C317B0C08E002475CF /* en */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = en; path = en.lproj/Main.storyboard; sourceTree = "<group>"; };
 		26F6F1C517B0D48D002475CF /* SFHFKeychainUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SFHFKeychainUtils.h; path = "../scifihifi-iphone/security/SFHFKeychainUtils.h"; sourceTree = "<group>"; };
 		26F6F1C617B0D48D002475CF /* SFHFKeychainUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SFHFKeychainUtils.m; path = "../scifihifi-iphone/security/SFHFKeychainUtils.m"; sourceTree = "<group>"; };
-		26F6F1C917B0D4BC002475CF /* AFHTTPClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AFHTTPClient.h; path = ../AFNetworking/AFNetworking/AFHTTPClient.h; sourceTree = "<group>"; };
-		26F6F1CA17B0D4BC002475CF /* AFHTTPClient.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AFHTTPClient.m; path = ../AFNetworking/AFNetworking/AFHTTPClient.m; sourceTree = "<group>"; };
-		26F6F1CB17B0D4BC002475CF /* AFHTTPRequestOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AFHTTPRequestOperation.h; path = ../AFNetworking/AFNetworking/AFHTTPRequestOperation.h; sourceTree = "<group>"; };
-		26F6F1CC17B0D4BC002475CF /* AFHTTPRequestOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AFHTTPRequestOperation.m; path = ../AFNetworking/AFNetworking/AFHTTPRequestOperation.m; sourceTree = "<group>"; };
-		26F6F1CD17B0D4BC002475CF /* AFImageRequestOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AFImageRequestOperation.h; path = ../AFNetworking/AFNetworking/AFImageRequestOperation.h; sourceTree = "<group>"; };
-		26F6F1CE17B0D4BC002475CF /* AFImageRequestOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AFImageRequestOperation.m; path = ../AFNetworking/AFNetworking/AFImageRequestOperation.m; sourceTree = "<group>"; };
-		26F6F1CF17B0D4BC002475CF /* AFJSONRequestOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AFJSONRequestOperation.h; path = ../AFNetworking/AFNetworking/AFJSONRequestOperation.h; sourceTree = "<group>"; };
-		26F6F1D017B0D4BC002475CF /* AFJSONRequestOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AFJSONRequestOperation.m; path = ../AFNetworking/AFNetworking/AFJSONRequestOperation.m; sourceTree = "<group>"; };
-		26F6F1D117B0D4BC002475CF /* AFNetworkActivityIndicatorManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AFNetworkActivityIndicatorManager.h; path = ../AFNetworking/AFNetworking/AFNetworkActivityIndicatorManager.h; sourceTree = "<group>"; };
-		26F6F1D217B0D4BC002475CF /* AFNetworkActivityIndicatorManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AFNetworkActivityIndicatorManager.m; path = ../AFNetworking/AFNetworking/AFNetworkActivityIndicatorManager.m; sourceTree = "<group>"; };
-		26F6F1D317B0D4BC002475CF /* AFNetworking.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AFNetworking.h; path = ../AFNetworking/AFNetworking/AFNetworking.h; sourceTree = "<group>"; };
-		26F6F1D417B0D4BC002475CF /* AFPropertyListRequestOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AFPropertyListRequestOperation.h; path = ../AFNetworking/AFNetworking/AFPropertyListRequestOperation.h; sourceTree = "<group>"; };
-		26F6F1D517B0D4BC002475CF /* AFPropertyListRequestOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AFPropertyListRequestOperation.m; path = ../AFNetworking/AFNetworking/AFPropertyListRequestOperation.m; sourceTree = "<group>"; };
-		26F6F1D617B0D4BC002475CF /* AFURLConnectionOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AFURLConnectionOperation.h; path = ../AFNetworking/AFNetworking/AFURLConnectionOperation.h; sourceTree = "<group>"; };
-		26F6F1D717B0D4BC002475CF /* AFURLConnectionOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AFURLConnectionOperation.m; path = ../AFNetworking/AFNetworking/AFURLConnectionOperation.m; sourceTree = "<group>"; };
-		26F6F1D817B0D4BC002475CF /* AFXMLRequestOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AFXMLRequestOperation.h; path = ../AFNetworking/AFNetworking/AFXMLRequestOperation.h; sourceTree = "<group>"; };
-		26F6F1D917B0D4BC002475CF /* AFXMLRequestOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AFXMLRequestOperation.m; path = ../AFNetworking/AFNetworking/AFXMLRequestOperation.m; sourceTree = "<group>"; };
-		26F6F1DA17B0D4BC002475CF /* UIImageView+AFNetworking.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "UIImageView+AFNetworking.h"; path = "../AFNetworking/AFNetworking/UIImageView+AFNetworking.h"; sourceTree = "<group>"; };
-		26F6F1DB17B0D4BC002475CF /* UIImageView+AFNetworking.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "UIImageView+AFNetworking.m"; path = "../AFNetworking/AFNetworking/UIImageView+AFNetworking.m"; sourceTree = "<group>"; };
 		26F6F1E517B0D549002475CF /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
 		7059EDF090D14D74B14658AE /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -186,6 +186,32 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		099A4BC918E028330085DD25 /* AFNetworking */ = {
+			isa = PBXGroup;
+			children = (
+				099A4BCA18E028330085DD25 /* HatenaAFHTTPClient.h */,
+				099A4BCB18E028330085DD25 /* HatenaAFHTTPClient.m */,
+				099A4BCC18E028330085DD25 /* HatenaAFHTTPRequestOperation.h */,
+				099A4BCD18E028330085DD25 /* HatenaAFHTTPRequestOperation.m */,
+				099A4BCE18E028330085DD25 /* HatenaAFImageRequestOperation.h */,
+				099A4BCF18E028330085DD25 /* HatenaAFImageRequestOperation.m */,
+				099A4BD018E028330085DD25 /* HatenaAFJSONRequestOperation.h */,
+				099A4BD118E028330085DD25 /* HatenaAFJSONRequestOperation.m */,
+				099A4BD218E028330085DD25 /* HatenaAFNetworkActivityIndicatorManager.h */,
+				099A4BD318E028330085DD25 /* HatenaAFNetworkActivityIndicatorManager.m */,
+				099A4BD418E028330085DD25 /* HatenaAFNetworking.h */,
+				099A4BD518E028330085DD25 /* HatenaAFPropertyListRequestOperation.h */,
+				099A4BD618E028330085DD25 /* HatenaAFPropertyListRequestOperation.m */,
+				099A4BD718E028330085DD25 /* HatenaAFURLConnectionOperation.h */,
+				099A4BD818E028330085DD25 /* HatenaAFURLConnectionOperation.m */,
+				099A4BD918E028330085DD25 /* HatenaAFXMLRequestOperation.h */,
+				099A4BDA18E028330085DD25 /* HatenaAFXMLRequestOperation.m */,
+				099A4BDB18E028330085DD25 /* UIImageView+HatenaAFNetworking.h */,
+				099A4BDC18E028330085DD25 /* UIImageView+HatenaAFNetworking.m */,
+			);
+			path = AFNetworking;
+			sourceTree = "<group>";
+		};
 		260BE3AB17AF1E2600BEA288 /* SDK */ = {
 			isa = PBXGroup;
 			children = (
@@ -204,6 +230,7 @@
 				26F6F1BF17B0A7DB002475CF /* HTBAFOAuth1Client.m */,
 				26F6F1BB17B0A7D1002475CF /* HTBHatenaBookmarkAPIClient.h */,
 				26F6F1BC17B0A7D1002475CF /* HTBHatenaBookmarkAPIClient.m */,
+				099A4BC918E028330085DD25 /* AFNetworking */,
 			);
 			path = API;
 			sourceTree = "<group>";
@@ -318,7 +345,6 @@
 				260BE3AB17AF1E2600BEA288 /* SDK */,
 				267CCBE5178A5D3900063953 /* DemoApp */,
 				26F6F1C417B0D478002475CF /* SFHFKeychainUtils */,
-				26F6F1C817B0D4A9002475CF /* AFNetworking */,
 				267CCBDE178A5D3900063953 /* Frameworks */,
 				267CCBDD178A5D3900063953 /* Products */,
 			);
@@ -383,32 +409,6 @@
 			);
 			name = SFHFKeychainUtils;
 			path = ../SDK;
-			sourceTree = "<group>";
-		};
-		26F6F1C817B0D4A9002475CF /* AFNetworking */ = {
-			isa = PBXGroup;
-			children = (
-				26F6F1C917B0D4BC002475CF /* AFHTTPClient.h */,
-				26F6F1CA17B0D4BC002475CF /* AFHTTPClient.m */,
-				26F6F1CB17B0D4BC002475CF /* AFHTTPRequestOperation.h */,
-				26F6F1CC17B0D4BC002475CF /* AFHTTPRequestOperation.m */,
-				26F6F1CD17B0D4BC002475CF /* AFImageRequestOperation.h */,
-				26F6F1CE17B0D4BC002475CF /* AFImageRequestOperation.m */,
-				26F6F1CF17B0D4BC002475CF /* AFJSONRequestOperation.h */,
-				26F6F1D017B0D4BC002475CF /* AFJSONRequestOperation.m */,
-				26F6F1D117B0D4BC002475CF /* AFNetworkActivityIndicatorManager.h */,
-				26F6F1D217B0D4BC002475CF /* AFNetworkActivityIndicatorManager.m */,
-				26F6F1D317B0D4BC002475CF /* AFNetworking.h */,
-				26F6F1D417B0D4BC002475CF /* AFPropertyListRequestOperation.h */,
-				26F6F1D517B0D4BC002475CF /* AFPropertyListRequestOperation.m */,
-				26F6F1D617B0D4BC002475CF /* AFURLConnectionOperation.h */,
-				26F6F1D717B0D4BC002475CF /* AFURLConnectionOperation.m */,
-				26F6F1D817B0D4BC002475CF /* AFXMLRequestOperation.h */,
-				26F6F1D917B0D4BC002475CF /* AFXMLRequestOperation.m */,
-				26F6F1DA17B0D4BC002475CF /* UIImageView+AFNetworking.h */,
-				26F6F1DB17B0D4BC002475CF /* UIImageView+AFNetworking.m */,
-			);
-			name = AFNetworking;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -483,6 +483,7 @@
 				267CCBF0178A5D3900063953 /* HTBAppDelegate.m in Sources */,
 				267CCBF6178A5D3900063953 /* HTBDemoViewController.m in Sources */,
 				260BE44D17AF1E2600BEA288 /* HTBHatenaBookmarkActivity.m in Sources */,
+				099A4BE218E028330085DD25 /* HatenaAFPropertyListRequestOperation.m in Sources */,
 				260BE44F17AF1E2600BEA288 /* HTBBookmarkedDataEntry.m in Sources */,
 				260BE45017AF1E2600BEA288 /* HTBBookmarkEntry.m in Sources */,
 				260BE45117AF1E2600BEA288 /* HTBMyEntry.m in Sources */,
@@ -495,9 +496,11 @@
 				260BE45817AF1E2600BEA288 /* HTBNavigationBar.m in Sources */,
 				260BE45917AF1E2600BEA288 /* HTBPlaceholderTextView.m in Sources */,
 				260BE45A17AF1E2600BEA288 /* HTBTagInputView.m in Sources */,
+				099A4BE318E028330085DD25 /* HatenaAFURLConnectionOperation.m in Sources */,
 				260BE45B17AF1E2600BEA288 /* HTBTagTextField.m in Sources */,
 				260BE45C17AF1E2600BEA288 /* HTBTagToolbarView.m in Sources */,
 				260BE45D17AF1E2600BEA288 /* HTBToggleButton.m in Sources */,
+				099A4BE018E028330085DD25 /* HatenaAFJSONRequestOperation.m in Sources */,
 				260BE45E17AF1E2600BEA288 /* HTBBookmarkViewController.m in Sources */,
 				260BE45F17AF1E2600BEA288 /* HTBCommentViewController.m in Sources */,
 				260BE46017AF1E2600BEA288 /* HTBLoginWebViewController.m in Sources */,
@@ -506,21 +509,18 @@
 				26F6F1BD17B0A7D1002475CF /* HTBHatenaBookmarkAPIClient.m in Sources */,
 				26F6F1C017B0A7DB002475CF /* HTBAFOAuth1Client.m in Sources */,
 				26F6F1C717B0D48D002475CF /* SFHFKeychainUtils.m in Sources */,
-				26F6F1DC17B0D4BC002475CF /* AFHTTPClient.m in Sources */,
-				26F6F1DD17B0D4BC002475CF /* AFHTTPRequestOperation.m in Sources */,
-				26F6F1DE17B0D4BC002475CF /* AFImageRequestOperation.m in Sources */,
-				26F6F1DF17B0D4BC002475CF /* AFJSONRequestOperation.m in Sources */,
-				26F6F1E017B0D4BC002475CF /* AFNetworkActivityIndicatorManager.m in Sources */,
-				26F6F1E117B0D4BC002475CF /* AFPropertyListRequestOperation.m in Sources */,
-				26F6F1E217B0D4BC002475CF /* AFURLConnectionOperation.m in Sources */,
-				26F6F1E317B0D4BC002475CF /* AFXMLRequestOperation.m in Sources */,
-				26F6F1E417B0D4BC002475CF /* UIImageView+AFNetworking.m in Sources */,
+				099A4BDD18E028330085DD25 /* HatenaAFHTTPClient.m in Sources */,
+				099A4BDF18E028330085DD25 /* HatenaAFImageRequestOperation.m in Sources */,
+				099A4BE118E028330085DD25 /* HatenaAFNetworkActivityIndicatorManager.m in Sources */,
+				099A4BE518E028330085DD25 /* UIImageView+HatenaAFNetworking.m in Sources */,
+				099A4BE418E028330085DD25 /* HatenaAFXMLRequestOperation.m in Sources */,
 				265F3E9B17B21D1400A89747 /* HTBMyTagsEntry.m in Sources */,
 				265F3E9E17B21E4A00A89747 /* HTBTagEntry.m in Sources */,
 				265F3EA317B2360E00A89747 /* HTBCanonicalEntry.m in Sources */,
 				265F3EA617B339A200A89747 /* HTBCanonicalView.m in Sources */,
 				265F3EAA17B4EA2200A89747 /* UIAlertView+HTBNSError.m in Sources */,
 				071C366017BE0478008EDF40 /* HTBAuthorizeEntry.m in Sources */,
+				099A4BDE18E028330085DD25 /* HatenaAFHTTPRequestOperation.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/HatenaBookmarkSDK.podspec
+++ b/HatenaBookmarkSDK.podspec
@@ -11,6 +11,5 @@ Pod::Spec.new do |s|
   s.frameworks = 'Foundation', 'Security', 'QuartzCore'
   s.requires_arc = true
   s.resource = 'SDK/UI/HTBResources.bundle'
-  s.dependency 'AFNetworking', '~> 1.0'
   s.dependency 'SFHFKeychainUtils'
 end

--- a/HatenaBookmarkSDK/HatenaBookmarkSDK.xcodeproj/project.pbxproj
+++ b/HatenaBookmarkSDK/HatenaBookmarkSDK.xcodeproj/project.pbxproj
@@ -161,16 +161,6 @@
 		070B7FE517BE378000ED4723 /* HTBTagEntrySpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 070B7F1517BE378000ED4723 /* HTBTagEntrySpec.m */; };
 		070B7FE617BE378000ED4723 /* HTBUserManagerSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 070B7F1617BE378000ED4723 /* HTBUserManagerSpec.m */; };
 		070B7FE717BE378000ED4723 /* HTBTagTokenizerSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 070B7F1817BE378000ED4723 /* HTBTagTokenizerSpec.m */; };
-		070B800F17BE386E00ED4723 /* AFHTTPClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 070B7FFC17BE386E00ED4723 /* AFHTTPClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		070B801117BE386E00ED4723 /* AFHTTPRequestOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 070B7FFE17BE386E00ED4723 /* AFHTTPRequestOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		070B801317BE386E00ED4723 /* AFImageRequestOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 070B800017BE386E00ED4723 /* AFImageRequestOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		070B801517BE386E00ED4723 /* AFJSONRequestOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 070B800217BE386E00ED4723 /* AFJSONRequestOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		070B801717BE386E00ED4723 /* AFNetworkActivityIndicatorManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 070B800417BE386E00ED4723 /* AFNetworkActivityIndicatorManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		070B801917BE386E00ED4723 /* AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 070B800617BE386E00ED4723 /* AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		070B801A17BE386E00ED4723 /* AFPropertyListRequestOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 070B800717BE386E00ED4723 /* AFPropertyListRequestOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		070B801C17BE386E00ED4723 /* AFURLConnectionOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 070B800917BE386E00ED4723 /* AFURLConnectionOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		070B801E17BE386E00ED4723 /* AFXMLRequestOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 070B800B17BE386E00ED4723 /* AFXMLRequestOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		070B802017BE386E00ED4723 /* UIImageView+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 070B800D17BE386E00ED4723 /* UIImageView+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		070B802517BE387900ED4723 /* SFHFKeychainUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 070B802317BE387900ED4723 /* SFHFKeychainUtils.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		070B802617BE387900ED4723 /* SFHFKeychainUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 070B802417BE387900ED4723 /* SFHFKeychainUtils.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		070B802817BE38AE00ED4723 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 070B802717BE38AE00ED4723 /* UIKit.framework */; };
@@ -499,25 +489,6 @@
 		070B7F1517BE378000ED4723 /* HTBTagEntrySpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HTBTagEntrySpec.m; sourceTree = "<group>"; };
 		070B7F1617BE378000ED4723 /* HTBUserManagerSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HTBUserManagerSpec.m; sourceTree = "<group>"; };
 		070B7F1817BE378000ED4723 /* HTBTagTokenizerSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HTBTagTokenizerSpec.m; sourceTree = "<group>"; };
-		070B7FFC17BE386E00ED4723 /* AFHTTPClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFHTTPClient.h; sourceTree = "<group>"; };
-		070B7FFD17BE386E00ED4723 /* AFHTTPClient.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFHTTPClient.m; sourceTree = "<group>"; };
-		070B7FFE17BE386E00ED4723 /* AFHTTPRequestOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFHTTPRequestOperation.h; sourceTree = "<group>"; };
-		070B7FFF17BE386E00ED4723 /* AFHTTPRequestOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFHTTPRequestOperation.m; sourceTree = "<group>"; };
-		070B800017BE386E00ED4723 /* AFImageRequestOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFImageRequestOperation.h; sourceTree = "<group>"; };
-		070B800117BE386E00ED4723 /* AFImageRequestOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFImageRequestOperation.m; sourceTree = "<group>"; };
-		070B800217BE386E00ED4723 /* AFJSONRequestOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFJSONRequestOperation.h; sourceTree = "<group>"; };
-		070B800317BE386E00ED4723 /* AFJSONRequestOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFJSONRequestOperation.m; sourceTree = "<group>"; };
-		070B800417BE386E00ED4723 /* AFNetworkActivityIndicatorManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFNetworkActivityIndicatorManager.h; sourceTree = "<group>"; };
-		070B800517BE386E00ED4723 /* AFNetworkActivityIndicatorManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFNetworkActivityIndicatorManager.m; sourceTree = "<group>"; };
-		070B800617BE386E00ED4723 /* AFNetworking.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFNetworking.h; sourceTree = "<group>"; };
-		070B800717BE386E00ED4723 /* AFPropertyListRequestOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFPropertyListRequestOperation.h; sourceTree = "<group>"; };
-		070B800817BE386E00ED4723 /* AFPropertyListRequestOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFPropertyListRequestOperation.m; sourceTree = "<group>"; };
-		070B800917BE386E00ED4723 /* AFURLConnectionOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFURLConnectionOperation.h; sourceTree = "<group>"; };
-		070B800A17BE386E00ED4723 /* AFURLConnectionOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFURLConnectionOperation.m; sourceTree = "<group>"; };
-		070B800B17BE386E00ED4723 /* AFXMLRequestOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFXMLRequestOperation.h; sourceTree = "<group>"; };
-		070B800C17BE386E00ED4723 /* AFXMLRequestOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFXMLRequestOperation.m; sourceTree = "<group>"; };
-		070B800D17BE386E00ED4723 /* UIImageView+AFNetworking.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIImageView+AFNetworking.h"; sourceTree = "<group>"; };
-		070B800E17BE386E00ED4723 /* UIImageView+AFNetworking.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIImageView+AFNetworking.m"; sourceTree = "<group>"; };
 		070B802317BE387900ED4723 /* SFHFKeychainUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SFHFKeychainUtils.h; sourceTree = "<group>"; };
 		070B802417BE387900ED4723 /* SFHFKeychainUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SFHFKeychainUtils.m; sourceTree = "<group>"; };
 		070B802717BE38AE00ED4723 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
@@ -662,7 +633,6 @@
 			isa = PBXGroup;
 			children = (
 				070B802217BE387900ED4723 /* SFHFKeychainUtils */,
-				070B7FFB17BE386E00ED4723 /* AFNetworking */,
 				070B79DD17BE36C500ED4723 /* Supporting Files */,
 			);
 			path = HatenaBookmarkSDK;
@@ -1099,33 +1069,6 @@
 			path = Util;
 			sourceTree = "<group>";
 		};
-		070B7FFB17BE386E00ED4723 /* AFNetworking */ = {
-			isa = PBXGroup;
-			children = (
-				070B7FFC17BE386E00ED4723 /* AFHTTPClient.h */,
-				070B7FFD17BE386E00ED4723 /* AFHTTPClient.m */,
-				070B7FFE17BE386E00ED4723 /* AFHTTPRequestOperation.h */,
-				070B7FFF17BE386E00ED4723 /* AFHTTPRequestOperation.m */,
-				070B800017BE386E00ED4723 /* AFImageRequestOperation.h */,
-				070B800117BE386E00ED4723 /* AFImageRequestOperation.m */,
-				070B800217BE386E00ED4723 /* AFJSONRequestOperation.h */,
-				070B800317BE386E00ED4723 /* AFJSONRequestOperation.m */,
-				070B800417BE386E00ED4723 /* AFNetworkActivityIndicatorManager.h */,
-				070B800517BE386E00ED4723 /* AFNetworkActivityIndicatorManager.m */,
-				070B800617BE386E00ED4723 /* AFNetworking.h */,
-				070B800717BE386E00ED4723 /* AFPropertyListRequestOperation.h */,
-				070B800817BE386E00ED4723 /* AFPropertyListRequestOperation.m */,
-				070B800917BE386E00ED4723 /* AFURLConnectionOperation.h */,
-				070B800A17BE386E00ED4723 /* AFURLConnectionOperation.m */,
-				070B800B17BE386E00ED4723 /* AFXMLRequestOperation.h */,
-				070B800C17BE386E00ED4723 /* AFXMLRequestOperation.m */,
-				070B800D17BE386E00ED4723 /* UIImageView+AFNetworking.h */,
-				070B800E17BE386E00ED4723 /* UIImageView+AFNetworking.m */,
-			);
-			name = AFNetworking;
-			path = ../../AFNetworking/AFNetworking;
-			sourceTree = "<group>";
-		};
 		070B802217BE387900ED4723 /* SFHFKeychainUtils */ = {
 			isa = PBXGroup;
 			children = (
@@ -1337,18 +1280,8 @@
 				070B7A8017BE370500ED4723 /* HTBHatenaBookmarkViewController.h in Headers */,
 				070B7A8217BE370500ED4723 /* HTBLoginWebViewController.h in Headers */,
 				070B7A4817BE370500ED4723 /* HTBAFOAuth1Client.h in Headers */,
-				070B800F17BE386E00ED4723 /* AFHTTPClient.h in Headers */,
-				070B801117BE386E00ED4723 /* AFHTTPRequestOperation.h in Headers */,
-				070B801317BE386E00ED4723 /* AFImageRequestOperation.h in Headers */,
-				070B801517BE386E00ED4723 /* AFJSONRequestOperation.h in Headers */,
-				070B801717BE386E00ED4723 /* AFNetworkActivityIndicatorManager.h in Headers */,
-				070B801917BE386E00ED4723 /* AFNetworking.h in Headers */,
-				070B801A17BE386E00ED4723 /* AFPropertyListRequestOperation.h in Headers */,
 				099A4BB618E0280E0085DD25 /* HatenaAFJSONRequestOperation.h in Headers */,
-				070B801C17BE386E00ED4723 /* AFURLConnectionOperation.h in Headers */,
 				099A4BB918E0280E0085DD25 /* HatenaAFNetworkActivityIndicatorManager.h in Headers */,
-				070B801E17BE386E00ED4723 /* AFXMLRequestOperation.h in Headers */,
-				070B802017BE386E00ED4723 /* UIImageView+AFNetworking.h in Headers */,
 				070B802517BE387900ED4723 /* SFHFKeychainUtils.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/HatenaBookmarkSDK/HatenaBookmarkSDK.xcodeproj/project.pbxproj
+++ b/HatenaBookmarkSDK/HatenaBookmarkSDK.xcodeproj/project.pbxproj
@@ -162,24 +162,15 @@
 		070B7FE617BE378000ED4723 /* HTBUserManagerSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 070B7F1617BE378000ED4723 /* HTBUserManagerSpec.m */; };
 		070B7FE717BE378000ED4723 /* HTBTagTokenizerSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 070B7F1817BE378000ED4723 /* HTBTagTokenizerSpec.m */; };
 		070B800F17BE386E00ED4723 /* AFHTTPClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 070B7FFC17BE386E00ED4723 /* AFHTTPClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		070B801017BE386E00ED4723 /* AFHTTPClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 070B7FFD17BE386E00ED4723 /* AFHTTPClient.m */; };
 		070B801117BE386E00ED4723 /* AFHTTPRequestOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 070B7FFE17BE386E00ED4723 /* AFHTTPRequestOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		070B801217BE386E00ED4723 /* AFHTTPRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 070B7FFF17BE386E00ED4723 /* AFHTTPRequestOperation.m */; };
 		070B801317BE386E00ED4723 /* AFImageRequestOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 070B800017BE386E00ED4723 /* AFImageRequestOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		070B801417BE386E00ED4723 /* AFImageRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 070B800117BE386E00ED4723 /* AFImageRequestOperation.m */; };
 		070B801517BE386E00ED4723 /* AFJSONRequestOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 070B800217BE386E00ED4723 /* AFJSONRequestOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		070B801617BE386E00ED4723 /* AFJSONRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 070B800317BE386E00ED4723 /* AFJSONRequestOperation.m */; };
 		070B801717BE386E00ED4723 /* AFNetworkActivityIndicatorManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 070B800417BE386E00ED4723 /* AFNetworkActivityIndicatorManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		070B801817BE386E00ED4723 /* AFNetworkActivityIndicatorManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 070B800517BE386E00ED4723 /* AFNetworkActivityIndicatorManager.m */; };
 		070B801917BE386E00ED4723 /* AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 070B800617BE386E00ED4723 /* AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		070B801A17BE386E00ED4723 /* AFPropertyListRequestOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 070B800717BE386E00ED4723 /* AFPropertyListRequestOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		070B801B17BE386E00ED4723 /* AFPropertyListRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 070B800817BE386E00ED4723 /* AFPropertyListRequestOperation.m */; };
 		070B801C17BE386E00ED4723 /* AFURLConnectionOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 070B800917BE386E00ED4723 /* AFURLConnectionOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		070B801D17BE386E00ED4723 /* AFURLConnectionOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 070B800A17BE386E00ED4723 /* AFURLConnectionOperation.m */; };
 		070B801E17BE386E00ED4723 /* AFXMLRequestOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 070B800B17BE386E00ED4723 /* AFXMLRequestOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		070B801F17BE386E00ED4723 /* AFXMLRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 070B800C17BE386E00ED4723 /* AFXMLRequestOperation.m */; };
 		070B802017BE386E00ED4723 /* UIImageView+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 070B800D17BE386E00ED4723 /* UIImageView+AFNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		070B802117BE386E00ED4723 /* UIImageView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = 070B800E17BE386E00ED4723 /* UIImageView+AFNetworking.m */; };
 		070B802517BE387900ED4723 /* SFHFKeychainUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 070B802317BE387900ED4723 /* SFHFKeychainUtils.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		070B802617BE387900ED4723 /* SFHFKeychainUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 070B802417BE387900ED4723 /* SFHFKeychainUtils.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		070B802817BE38AE00ED4723 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 070B802717BE38AE00ED4723 /* UIKit.framework */; };
@@ -210,6 +201,34 @@
 		070B808417BE3B9600ED4723 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 070B808317BE3B9600ED4723 /* Security.framework */; };
 		070B808517BE3BA400ED4723 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 070B802917BE38DF00ED4723 /* SystemConfiguration.framework */; };
 		070B808617BE3BBF00ED4723 /* MobileCoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 070B802B17BE38E900ED4723 /* MobileCoreServices.framework */; };
+		099A4BAD18E0280E0085DD25 /* HatenaAFHTTPClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 099A4B9A18E0280E0085DD25 /* HatenaAFHTTPClient.h */; };
+		099A4BAE18E0280E0085DD25 /* HatenaAFHTTPClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 099A4B9B18E0280E0085DD25 /* HatenaAFHTTPClient.m */; };
+		099A4BAF18E0280E0085DD25 /* HatenaAFHTTPClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 099A4B9B18E0280E0085DD25 /* HatenaAFHTTPClient.m */; };
+		099A4BB018E0280E0085DD25 /* HatenaAFHTTPRequestOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 099A4B9C18E0280E0085DD25 /* HatenaAFHTTPRequestOperation.h */; };
+		099A4BB118E0280E0085DD25 /* HatenaAFHTTPRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 099A4B9D18E0280E0085DD25 /* HatenaAFHTTPRequestOperation.m */; };
+		099A4BB218E0280E0085DD25 /* HatenaAFHTTPRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 099A4B9D18E0280E0085DD25 /* HatenaAFHTTPRequestOperation.m */; };
+		099A4BB318E0280E0085DD25 /* HatenaAFImageRequestOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 099A4B9E18E0280E0085DD25 /* HatenaAFImageRequestOperation.h */; };
+		099A4BB418E0280E0085DD25 /* HatenaAFImageRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 099A4B9F18E0280E0085DD25 /* HatenaAFImageRequestOperation.m */; };
+		099A4BB518E0280E0085DD25 /* HatenaAFImageRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 099A4B9F18E0280E0085DD25 /* HatenaAFImageRequestOperation.m */; };
+		099A4BB618E0280E0085DD25 /* HatenaAFJSONRequestOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 099A4BA018E0280E0085DD25 /* HatenaAFJSONRequestOperation.h */; };
+		099A4BB718E0280E0085DD25 /* HatenaAFJSONRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 099A4BA118E0280E0085DD25 /* HatenaAFJSONRequestOperation.m */; };
+		099A4BB818E0280E0085DD25 /* HatenaAFJSONRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 099A4BA118E0280E0085DD25 /* HatenaAFJSONRequestOperation.m */; };
+		099A4BB918E0280E0085DD25 /* HatenaAFNetworkActivityIndicatorManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 099A4BA218E0280E0085DD25 /* HatenaAFNetworkActivityIndicatorManager.h */; };
+		099A4BBA18E0280E0085DD25 /* HatenaAFNetworkActivityIndicatorManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 099A4BA318E0280E0085DD25 /* HatenaAFNetworkActivityIndicatorManager.m */; };
+		099A4BBB18E0280E0085DD25 /* HatenaAFNetworkActivityIndicatorManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 099A4BA318E0280E0085DD25 /* HatenaAFNetworkActivityIndicatorManager.m */; };
+		099A4BBC18E0280E0085DD25 /* HatenaAFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 099A4BA418E0280E0085DD25 /* HatenaAFNetworking.h */; };
+		099A4BBD18E0280E0085DD25 /* HatenaAFPropertyListRequestOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 099A4BA518E0280E0085DD25 /* HatenaAFPropertyListRequestOperation.h */; };
+		099A4BBE18E0280E0085DD25 /* HatenaAFPropertyListRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 099A4BA618E0280E0085DD25 /* HatenaAFPropertyListRequestOperation.m */; };
+		099A4BBF18E0280E0085DD25 /* HatenaAFPropertyListRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 099A4BA618E0280E0085DD25 /* HatenaAFPropertyListRequestOperation.m */; };
+		099A4BC018E0280E0085DD25 /* HatenaAFURLConnectionOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 099A4BA718E0280E0085DD25 /* HatenaAFURLConnectionOperation.h */; };
+		099A4BC118E0280E0085DD25 /* HatenaAFURLConnectionOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 099A4BA818E0280E0085DD25 /* HatenaAFURLConnectionOperation.m */; };
+		099A4BC218E0280E0085DD25 /* HatenaAFURLConnectionOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 099A4BA818E0280E0085DD25 /* HatenaAFURLConnectionOperation.m */; };
+		099A4BC318E0280E0085DD25 /* HatenaAFXMLRequestOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 099A4BA918E0280E0085DD25 /* HatenaAFXMLRequestOperation.h */; };
+		099A4BC418E0280E0085DD25 /* HatenaAFXMLRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 099A4BAA18E0280E0085DD25 /* HatenaAFXMLRequestOperation.m */; };
+		099A4BC518E0280E0085DD25 /* HatenaAFXMLRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 099A4BAA18E0280E0085DD25 /* HatenaAFXMLRequestOperation.m */; };
+		099A4BC618E0280E0085DD25 /* UIImageView+HatenaAFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 099A4BAB18E0280E0085DD25 /* UIImageView+HatenaAFNetworking.h */; };
+		099A4BC718E0280E0085DD25 /* UIImageView+HatenaAFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = 099A4BAC18E0280E0085DD25 /* UIImageView+HatenaAFNetworking.m */; };
+		099A4BC818E0280E0085DD25 /* UIImageView+HatenaAFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = 099A4BAC18E0280E0085DD25 /* UIImageView+HatenaAFNetworking.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -240,7 +259,7 @@
 		070B7A0617BE370500ED4723 /* HTBAFOAuth1Client.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HTBAFOAuth1Client.h; sourceTree = "<group>"; };
 		070B7A0717BE370500ED4723 /* HTBAFOAuth1Client.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HTBAFOAuth1Client.m; sourceTree = "<group>"; };
 		070B7A0817BE370500ED4723 /* HTBHatenaBookmarkAPIClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HTBHatenaBookmarkAPIClient.h; sourceTree = "<group>"; };
-		070B7A0917BE370500ED4723 /* HTBHatenaBookmarkAPIClient.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HTBHatenaBookmarkAPIClient.m; sourceTree = "<group>"; };
+		070B7A0917BE370500ED4723 /* HTBHatenaBookmarkAPIClient.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HTBHatenaBookmarkAPIClient.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		070B7A0A17BE370500ED4723 /* HatenaBookmarkSDK.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HatenaBookmarkSDK.h; sourceTree = "<group>"; };
 		070B7A0C17BE370500ED4723 /* HTBHatenaBookmarkActivity.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HTBHatenaBookmarkActivity.h; sourceTree = "<group>"; };
 		070B7A0D17BE370500ED4723 /* HTBHatenaBookmarkActivity.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HTBHatenaBookmarkActivity.m; sourceTree = "<group>"; };
@@ -556,6 +575,25 @@
 		070B806917BE3A1400ED4723 /* LSStubResponse.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LSStubResponse.m; sourceTree = "<group>"; };
 		070B808017BE3B1600ED4723 /* CFNetwork.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CFNetwork.framework; path = System/Library/Frameworks/CFNetwork.framework; sourceTree = SDKROOT; };
 		070B808317BE3B9600ED4723 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
+		099A4B9A18E0280E0085DD25 /* HatenaAFHTTPClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HatenaAFHTTPClient.h; sourceTree = "<group>"; };
+		099A4B9B18E0280E0085DD25 /* HatenaAFHTTPClient.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HatenaAFHTTPClient.m; sourceTree = "<group>"; };
+		099A4B9C18E0280E0085DD25 /* HatenaAFHTTPRequestOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HatenaAFHTTPRequestOperation.h; sourceTree = "<group>"; };
+		099A4B9D18E0280E0085DD25 /* HatenaAFHTTPRequestOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HatenaAFHTTPRequestOperation.m; sourceTree = "<group>"; };
+		099A4B9E18E0280E0085DD25 /* HatenaAFImageRequestOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HatenaAFImageRequestOperation.h; sourceTree = "<group>"; };
+		099A4B9F18E0280E0085DD25 /* HatenaAFImageRequestOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HatenaAFImageRequestOperation.m; sourceTree = "<group>"; };
+		099A4BA018E0280E0085DD25 /* HatenaAFJSONRequestOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HatenaAFJSONRequestOperation.h; sourceTree = "<group>"; };
+		099A4BA118E0280E0085DD25 /* HatenaAFJSONRequestOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HatenaAFJSONRequestOperation.m; sourceTree = "<group>"; };
+		099A4BA218E0280E0085DD25 /* HatenaAFNetworkActivityIndicatorManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HatenaAFNetworkActivityIndicatorManager.h; sourceTree = "<group>"; };
+		099A4BA318E0280E0085DD25 /* HatenaAFNetworkActivityIndicatorManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HatenaAFNetworkActivityIndicatorManager.m; sourceTree = "<group>"; };
+		099A4BA418E0280E0085DD25 /* HatenaAFNetworking.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HatenaAFNetworking.h; sourceTree = "<group>"; };
+		099A4BA518E0280E0085DD25 /* HatenaAFPropertyListRequestOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HatenaAFPropertyListRequestOperation.h; sourceTree = "<group>"; };
+		099A4BA618E0280E0085DD25 /* HatenaAFPropertyListRequestOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HatenaAFPropertyListRequestOperation.m; sourceTree = "<group>"; };
+		099A4BA718E0280E0085DD25 /* HatenaAFURLConnectionOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HatenaAFURLConnectionOperation.h; sourceTree = "<group>"; };
+		099A4BA818E0280E0085DD25 /* HatenaAFURLConnectionOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HatenaAFURLConnectionOperation.m; sourceTree = "<group>"; };
+		099A4BA918E0280E0085DD25 /* HatenaAFXMLRequestOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HatenaAFXMLRequestOperation.h; sourceTree = "<group>"; };
+		099A4BAA18E0280E0085DD25 /* HatenaAFXMLRequestOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HatenaAFXMLRequestOperation.m; sourceTree = "<group>"; };
+		099A4BAB18E0280E0085DD25 /* UIImageView+HatenaAFNetworking.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIImageView+HatenaAFNetworking.h"; sourceTree = "<group>"; };
+		099A4BAC18E0280E0085DD25 /* UIImageView+HatenaAFNetworking.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIImageView+HatenaAFNetworking.m"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -658,6 +696,7 @@
 				070B7A0717BE370500ED4723 /* HTBAFOAuth1Client.m */,
 				070B7A0817BE370500ED4723 /* HTBHatenaBookmarkAPIClient.h */,
 				070B7A0917BE370500ED4723 /* HTBHatenaBookmarkAPIClient.m */,
+				099A4B9918E0280E0085DD25 /* AFNetworking */,
 			);
 			path = API;
 			sourceTree = "<group>";
@@ -1227,6 +1266,32 @@
 			path = Stubs;
 			sourceTree = "<group>";
 		};
+		099A4B9918E0280E0085DD25 /* AFNetworking */ = {
+			isa = PBXGroup;
+			children = (
+				099A4B9A18E0280E0085DD25 /* HatenaAFHTTPClient.h */,
+				099A4B9B18E0280E0085DD25 /* HatenaAFHTTPClient.m */,
+				099A4B9C18E0280E0085DD25 /* HatenaAFHTTPRequestOperation.h */,
+				099A4B9D18E0280E0085DD25 /* HatenaAFHTTPRequestOperation.m */,
+				099A4B9E18E0280E0085DD25 /* HatenaAFImageRequestOperation.h */,
+				099A4B9F18E0280E0085DD25 /* HatenaAFImageRequestOperation.m */,
+				099A4BA018E0280E0085DD25 /* HatenaAFJSONRequestOperation.h */,
+				099A4BA118E0280E0085DD25 /* HatenaAFJSONRequestOperation.m */,
+				099A4BA218E0280E0085DD25 /* HatenaAFNetworkActivityIndicatorManager.h */,
+				099A4BA318E0280E0085DD25 /* HatenaAFNetworkActivityIndicatorManager.m */,
+				099A4BA418E0280E0085DD25 /* HatenaAFNetworking.h */,
+				099A4BA518E0280E0085DD25 /* HatenaAFPropertyListRequestOperation.h */,
+				099A4BA618E0280E0085DD25 /* HatenaAFPropertyListRequestOperation.m */,
+				099A4BA718E0280E0085DD25 /* HatenaAFURLConnectionOperation.h */,
+				099A4BA818E0280E0085DD25 /* HatenaAFURLConnectionOperation.m */,
+				099A4BA918E0280E0085DD25 /* HatenaAFXMLRequestOperation.h */,
+				099A4BAA18E0280E0085DD25 /* HatenaAFXMLRequestOperation.m */,
+				099A4BAB18E0280E0085DD25 /* UIImageView+HatenaAFNetworking.h */,
+				099A4BAC18E0280E0085DD25 /* UIImageView+HatenaAFNetworking.m */,
+			);
+			path = AFNetworking;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -1236,10 +1301,12 @@
 			files = (
 				070B7A4C17BE370500ED4723 /* HatenaBookmarkSDK.h in Headers */,
 				070B7A4A17BE370500ED4723 /* HTBHatenaBookmarkAPIClient.h in Headers */,
+				099A4BB018E0280E0085DD25 /* HatenaAFHTTPRequestOperation.h in Headers */,
 				070B7A4D17BE370500ED4723 /* HTBHatenaBookmarkActivity.h in Headers */,
 				070B7A5017BE370500ED4723 /* HTBAuthorizeEntry.h in Headers */,
 				070B7A5217BE370500ED4723 /* HTBBookmarkedDataEntry.h in Headers */,
 				070B7A5417BE370500ED4723 /* HTBBookmarkEntry.h in Headers */,
+				099A4BC018E0280E0085DD25 /* HatenaAFURLConnectionOperation.h in Headers */,
 				070B7A5617BE370500ED4723 /* HTBCanonicalEntry.h in Headers */,
 				070B7A5817BE370500ED4723 /* HTBMyEntry.h in Headers */,
 				070B7A5A17BE370500ED4723 /* HTBMyTagsEntry.h in Headers */,
@@ -1248,7 +1315,9 @@
 				070B7A6017BE370500ED4723 /* HTBUserManager.h in Headers */,
 				070B7A6217BE370500ED4723 /* HTBTagTokenizer.h in Headers */,
 				070B7A6417BE370500ED4723 /* HTBUtility.h in Headers */,
+				099A4BBD18E0280E0085DD25 /* HatenaAFPropertyListRequestOperation.h in Headers */,
 				070B7A6617BE370500ED4723 /* UIAlertView+HTBNSError.h in Headers */,
+				099A4BAD18E0280E0085DD25 /* HatenaAFHTTPClient.h in Headers */,
 				070B7A6817BE370500ED4723 /* HTBBookmarkEntryView.h in Headers */,
 				070B7A6A17BE370500ED4723 /* HTBBookmarkRootView.h in Headers */,
 				070B7A6C17BE370500ED4723 /* HTBBookmarkToolbarView.h in Headers */,
@@ -1256,8 +1325,12 @@
 				070B7A7017BE370500ED4723 /* HTBNavigationBar.h in Headers */,
 				070B7A7217BE370500ED4723 /* HTBPlaceholderTextView.h in Headers */,
 				070B7A7417BE370500ED4723 /* HTBTagInputView.h in Headers */,
+				099A4BC318E0280E0085DD25 /* HatenaAFXMLRequestOperation.h in Headers */,
 				070B7A7617BE370500ED4723 /* HTBTagTextField.h in Headers */,
 				070B7A7817BE370500ED4723 /* HTBTagToolbarView.h in Headers */,
+				099A4BBC18E0280E0085DD25 /* HatenaAFNetworking.h in Headers */,
+				099A4BC618E0280E0085DD25 /* UIImageView+HatenaAFNetworking.h in Headers */,
+				099A4BB318E0280E0085DD25 /* HatenaAFImageRequestOperation.h in Headers */,
 				070B7A7A17BE370500ED4723 /* HTBToggleButton.h in Headers */,
 				070B7A7C17BE370500ED4723 /* HTBBookmarkViewController.h in Headers */,
 				070B7A7E17BE370500ED4723 /* HTBCommentViewController.h in Headers */,
@@ -1271,7 +1344,9 @@
 				070B801717BE386E00ED4723 /* AFNetworkActivityIndicatorManager.h in Headers */,
 				070B801917BE386E00ED4723 /* AFNetworking.h in Headers */,
 				070B801A17BE386E00ED4723 /* AFPropertyListRequestOperation.h in Headers */,
+				099A4BB618E0280E0085DD25 /* HatenaAFJSONRequestOperation.h in Headers */,
 				070B801C17BE386E00ED4723 /* AFURLConnectionOperation.h in Headers */,
+				099A4BB918E0280E0085DD25 /* HatenaAFNetworkActivityIndicatorManager.h in Headers */,
 				070B801E17BE386E00ED4723 /* AFXMLRequestOperation.h in Headers */,
 				070B802017BE386E00ED4723 /* UIImageView+AFNetworking.h in Headers */,
 				070B802517BE387900ED4723 /* SFHFKeychainUtils.h in Headers */,
@@ -1328,6 +1403,7 @@
 		070B79CB17BE36C500ED4723 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				LastTestingUpgradeCheck = 0510;
 				LastUpgradeCheck = 0460;
 			};
 			buildConfigurationList = 070B79CE17BE36C500ED4723 /* Build configuration list for PBXProject "HatenaBookmarkSDK" */;
@@ -1428,24 +1504,32 @@
 			buildActionMask = 2147483647;
 			files = (
 				070B7A4917BE370500ED4723 /* HTBAFOAuth1Client.m in Sources */,
+				099A4BBE18E0280E0085DD25 /* HatenaAFPropertyListRequestOperation.m in Sources */,
 				070B7A4B17BE370500ED4723 /* HTBHatenaBookmarkAPIClient.m in Sources */,
 				070B7A4E17BE370500ED4723 /* HTBHatenaBookmarkActivity.m in Sources */,
+				099A4BC718E0280E0085DD25 /* UIImageView+HatenaAFNetworking.m in Sources */,
 				070B7A5117BE370500ED4723 /* HTBAuthorizeEntry.m in Sources */,
 				070B7A5317BE370500ED4723 /* HTBBookmarkedDataEntry.m in Sources */,
 				070B7A5517BE370500ED4723 /* HTBBookmarkEntry.m in Sources */,
 				070B7A5717BE370500ED4723 /* HTBCanonicalEntry.m in Sources */,
 				070B7A5917BE370500ED4723 /* HTBMyEntry.m in Sources */,
+				099A4BB118E0280E0085DD25 /* HatenaAFHTTPRequestOperation.m in Sources */,
 				070B7A5B17BE370500ED4723 /* HTBMyTagsEntry.m in Sources */,
 				070B7A5D17BE370500ED4723 /* HTBTagEntry.m in Sources */,
 				070B7A5F17BE370500ED4723 /* HTBHatenaBookmarkManager.m in Sources */,
 				070B7A6117BE370500ED4723 /* HTBUserManager.m in Sources */,
 				070B7A6317BE370500ED4723 /* HTBTagTokenizer.m in Sources */,
 				070B7A6517BE370500ED4723 /* HTBUtility.m in Sources */,
+				099A4BC118E0280E0085DD25 /* HatenaAFURLConnectionOperation.m in Sources */,
+				099A4BBA18E0280E0085DD25 /* HatenaAFNetworkActivityIndicatorManager.m in Sources */,
+				099A4BAE18E0280E0085DD25 /* HatenaAFHTTPClient.m in Sources */,
 				070B7A6717BE370500ED4723 /* UIAlertView+HTBNSError.m in Sources */,
 				070B7A6917BE370500ED4723 /* HTBBookmarkEntryView.m in Sources */,
+				099A4BB718E0280E0085DD25 /* HatenaAFJSONRequestOperation.m in Sources */,
 				070B7A6B17BE370500ED4723 /* HTBBookmarkRootView.m in Sources */,
 				070B7A6D17BE370500ED4723 /* HTBBookmarkToolbarView.m in Sources */,
 				070B7A6F17BE370500ED4723 /* HTBCanonicalView.m in Sources */,
+				099A4BB418E0280E0085DD25 /* HatenaAFImageRequestOperation.m in Sources */,
 				070B7A7117BE370500ED4723 /* HTBNavigationBar.m in Sources */,
 				070B7A7317BE370500ED4723 /* HTBPlaceholderTextView.m in Sources */,
 				070B7A7517BE370500ED4723 /* HTBTagInputView.m in Sources */,
@@ -1456,15 +1540,7 @@
 				070B7A7F17BE370500ED4723 /* HTBCommentViewController.m in Sources */,
 				070B7A8117BE370500ED4723 /* HTBHatenaBookmarkViewController.m in Sources */,
 				070B7A8317BE370500ED4723 /* HTBLoginWebViewController.m in Sources */,
-				070B801017BE386E00ED4723 /* AFHTTPClient.m in Sources */,
-				070B801217BE386E00ED4723 /* AFHTTPRequestOperation.m in Sources */,
-				070B801417BE386E00ED4723 /* AFImageRequestOperation.m in Sources */,
-				070B801617BE386E00ED4723 /* AFJSONRequestOperation.m in Sources */,
-				070B801817BE386E00ED4723 /* AFNetworkActivityIndicatorManager.m in Sources */,
-				070B801B17BE386E00ED4723 /* AFPropertyListRequestOperation.m in Sources */,
-				070B801D17BE386E00ED4723 /* AFURLConnectionOperation.m in Sources */,
-				070B801F17BE386E00ED4723 /* AFXMLRequestOperation.m in Sources */,
-				070B802117BE386E00ED4723 /* UIImageView+AFNetworking.m in Sources */,
+				099A4BC418E0280E0085DD25 /* HatenaAFXMLRequestOperation.m in Sources */,
 				070B802617BE387900ED4723 /* SFHFKeychainUtils.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1483,6 +1559,7 @@
 				070B7F2717BE378000ED4723 /* KWExampleSuiteBuilder.m in Sources */,
 				070B7F2817BE378000ED4723 /* KWFailure.m in Sources */,
 				070B7F2917BE378000ED4723 /* KWFormatter.m in Sources */,
+				099A4BBF18E0280E0085DD25 /* HatenaAFPropertyListRequestOperation.m in Sources */,
 				070B7F2A17BE378000ED4723 /* KWFutureObject.m in Sources */,
 				070B7F2B17BE378000ED4723 /* KWInvocationCapturer.m in Sources */,
 				070B7F2C17BE378000ED4723 /* KWMatcher.m in Sources */,
@@ -1500,11 +1577,13 @@
 				070B7F3817BE378000ED4723 /* NSInvocation+OCMAdditions.m in Sources */,
 				070B7F3917BE378000ED4723 /* NSMethodSignature+KiwiAdditions.m in Sources */,
 				070B7F3A17BE378000ED4723 /* NSNumber+KiwiAdditions.m in Sources */,
+				099A4BC818E0280E0085DD25 /* UIImageView+HatenaAFNetworking.m in Sources */,
 				070B7F3B17BE378000ED4723 /* NSObject+KiwiSpyAdditions.m in Sources */,
 				070B7F3C17BE378000ED4723 /* NSObject+KiwiVerifierAdditions.m in Sources */,
 				070B7F3D17BE378000ED4723 /* NSProxy+KiwiVerifierAdditions.m in Sources */,
 				070B7F3E17BE378000ED4723 /* NSValue+KiwiAdditions.m in Sources */,
 				070B7F3F17BE378000ED4723 /* SenTestSuite+KiwiAdditions.m in Sources */,
+				099A4BC518E0280E0085DD25 /* HatenaAFXMLRequestOperation.m in Sources */,
 				070B7F4017BE378000ED4723 /* KWBeBetweenMatcher.m in Sources */,
 				070B7F4117BE378000ED4723 /* KWBeEmptyMatcher.m in Sources */,
 				070B7F4217BE378000ED4723 /* KWBeIdenticalToMatcher.m in Sources */,
@@ -1527,6 +1606,7 @@
 				070B7F5317BE378000ED4723 /* KWHaveValueMatcher.m in Sources */,
 				070B7F5417BE378000ED4723 /* KWInequalityMatcher.m in Sources */,
 				070B7F5517BE378000ED4723 /* KWNilMatcher.m in Sources */,
+				099A4BAF18E0280E0085DD25 /* HatenaAFHTTPClient.m in Sources */,
 				070B7F5617BE378000ED4723 /* KWRaiseMatcher.m in Sources */,
 				070B7F5717BE378000ED4723 /* KWReceiveMatcher.m in Sources */,
 				070B7F5817BE378000ED4723 /* KWRegularExpressionPatternMatcher.m in Sources */,
@@ -1537,6 +1617,7 @@
 				070B7F5D17BE378000ED4723 /* KWMock.m in Sources */,
 				070B7F5E17BE378000ED4723 /* NSObject+KiwiMockAdditions.m in Sources */,
 				070B7F5F17BE378000ED4723 /* KWAfterAllNode.m in Sources */,
+				099A4BB818E0280E0085DD25 /* HatenaAFJSONRequestOperation.m in Sources */,
 				070B7F6017BE378000ED4723 /* KWAfterEachNode.m in Sources */,
 				070B7F6117BE378000ED4723 /* KWBeforeAllNode.m in Sources */,
 				070B7F6217BE378000ED4723 /* KWBeforeEachNode.m in Sources */,
@@ -1571,6 +1652,8 @@
 				070B807017BE3A1400ED4723 /* ASIHTTPRequestStub.m in Sources */,
 				070B807117BE3A1400ED4723 /* LSASIHTTPRequestAdapter.m in Sources */,
 				070B807217BE3A1400ED4723 /* LSASIHTTPRequestHook.m in Sources */,
+				099A4BB218E0280E0085DD25 /* HatenaAFHTTPRequestOperation.m in Sources */,
+				099A4BC218E0280E0085DD25 /* HatenaAFURLConnectionOperation.m in Sources */,
 				070B807317BE3A1400ED4723 /* LSHTTPClientHook.m in Sources */,
 				070B807417BE3A1400ED4723 /* LSHTTPStubURLProtocol.m in Sources */,
 				070B807517BE3A1400ED4723 /* LSNSURLHook.m in Sources */,
@@ -1581,7 +1664,9 @@
 				070B807A17BE3A1400ED4723 /* LSRegexMatcher.m in Sources */,
 				070B807B17BE3A1400ED4723 /* LSStringMatcher.m in Sources */,
 				070B807C17BE3A1400ED4723 /* NSRegularExpression+Matcheable.m in Sources */,
+				099A4BBB18E0280E0085DD25 /* HatenaAFNetworkActivityIndicatorManager.m in Sources */,
 				070B807D17BE3A1400ED4723 /* NSString+Matcheable.m in Sources */,
+				099A4BB518E0280E0085DD25 /* HatenaAFImageRequestOperation.m in Sources */,
 				070B807E17BE3A1400ED4723 /* LSStubRequest.m in Sources */,
 				070B807F17BE3A1400ED4723 /* LSStubResponse.m in Sources */,
 			);

--- a/HatenaBookmarkSDKTests/HatenaBookmarkSDKTests.xcodeproj/project.pbxproj
+++ b/HatenaBookmarkSDKTests/HatenaBookmarkSDKTests.xcodeproj/project.pbxproj
@@ -150,15 +150,6 @@
 		0788586017BDFC5300DF0CBD /* HTBCommentViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0788584117BDFC5300DF0CBD /* HTBCommentViewController.m */; };
 		0788586117BDFC5300DF0CBD /* HTBHatenaBookmarkViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0788584317BDFC5300DF0CBD /* HTBHatenaBookmarkViewController.m */; };
 		0788586217BDFC5300DF0CBD /* HTBLoginWebViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0788584517BDFC5300DF0CBD /* HTBLoginWebViewController.m */; };
-		0788587717BDFC7100DF0CBD /* AFHTTPClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 0788586517BDFC7100DF0CBD /* AFHTTPClient.m */; };
-		0788587817BDFC7100DF0CBD /* AFHTTPRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 0788586717BDFC7100DF0CBD /* AFHTTPRequestOperation.m */; };
-		0788587917BDFC7100DF0CBD /* AFImageRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 0788586917BDFC7100DF0CBD /* AFImageRequestOperation.m */; };
-		0788587A17BDFC7100DF0CBD /* AFJSONRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 0788586B17BDFC7100DF0CBD /* AFJSONRequestOperation.m */; };
-		0788587B17BDFC7100DF0CBD /* AFNetworkActivityIndicatorManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 0788586D17BDFC7100DF0CBD /* AFNetworkActivityIndicatorManager.m */; };
-		0788587C17BDFC7100DF0CBD /* AFPropertyListRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 0788587017BDFC7100DF0CBD /* AFPropertyListRequestOperation.m */; };
-		0788587D17BDFC7100DF0CBD /* AFURLConnectionOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 0788587217BDFC7100DF0CBD /* AFURLConnectionOperation.m */; };
-		0788587E17BDFC7100DF0CBD /* AFXMLRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 0788587417BDFC7100DF0CBD /* AFXMLRequestOperation.m */; };
-		0788587F17BDFC7100DF0CBD /* UIImageView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = 0788587617BDFC7100DF0CBD /* UIImageView+AFNetworking.m */; };
 		0788588E17BDFC7F00DF0CBD /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 0788588117BDFC7F00DF0CBD /* README.md */; };
 		0788588F17BDFC7F00DF0CBD /* SFHFKeychainUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 0788588417BDFC7F00DF0CBD /* SFHFKeychainUtils.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		0788589517BDFD8800DF0CBD /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0788589417BDFD8800DF0CBD /* Security.framework */; };
@@ -167,6 +158,15 @@
 		0788589A17BDFD9E00DF0CBD /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0788589917BDFD9E00DF0CBD /* SystemConfiguration.framework */; };
 		0788589C17BDFDA700DF0CBD /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0788589B17BDFDA700DF0CBD /* QuartzCore.framework */; };
 		0788589E17BDFDAD00DF0CBD /* MobileCoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0788589D17BDFDAD00DF0CBD /* MobileCoreServices.framework */; };
+		099A4BFA18E02FBC0085DD25 /* HatenaAFHTTPClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 099A4BE818E02FBC0085DD25 /* HatenaAFHTTPClient.m */; };
+		099A4BFB18E02FBC0085DD25 /* HatenaAFHTTPRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 099A4BEA18E02FBC0085DD25 /* HatenaAFHTTPRequestOperation.m */; };
+		099A4BFC18E02FBC0085DD25 /* HatenaAFImageRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 099A4BEC18E02FBC0085DD25 /* HatenaAFImageRequestOperation.m */; };
+		099A4BFD18E02FBC0085DD25 /* HatenaAFJSONRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 099A4BEE18E02FBC0085DD25 /* HatenaAFJSONRequestOperation.m */; };
+		099A4BFE18E02FBC0085DD25 /* HatenaAFNetworkActivityIndicatorManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 099A4BF018E02FBC0085DD25 /* HatenaAFNetworkActivityIndicatorManager.m */; };
+		099A4BFF18E02FBC0085DD25 /* HatenaAFPropertyListRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 099A4BF318E02FBC0085DD25 /* HatenaAFPropertyListRequestOperation.m */; };
+		099A4C0018E02FBC0085DD25 /* HatenaAFURLConnectionOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 099A4BF518E02FBC0085DD25 /* HatenaAFURLConnectionOperation.m */; };
+		099A4C0118E02FBC0085DD25 /* HatenaAFXMLRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 099A4BF718E02FBC0085DD25 /* HatenaAFXMLRequestOperation.m */; };
+		099A4C0218E02FBC0085DD25 /* UIImageView+HatenaAFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = 099A4BF918E02FBC0085DD25 /* UIImageView+HatenaAFNetworking.m */; };
 		1AB89299C48775FF2B1096DA /* HTBAuthorizeEntry.m in Sources */ = {isa = PBXBuildFile; fileRef = 1AB89A9AA4B98C05BD475DCC /* HTBAuthorizeEntry.m */; };
 /* End PBXBuildFile section */
 
@@ -475,25 +475,6 @@
 		0788584317BDFC5300DF0CBD /* HTBHatenaBookmarkViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HTBHatenaBookmarkViewController.m; sourceTree = "<group>"; };
 		0788584417BDFC5300DF0CBD /* HTBLoginWebViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HTBLoginWebViewController.h; sourceTree = "<group>"; };
 		0788584517BDFC5300DF0CBD /* HTBLoginWebViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HTBLoginWebViewController.m; sourceTree = "<group>"; };
-		0788586417BDFC7100DF0CBD /* AFHTTPClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFHTTPClient.h; sourceTree = "<group>"; };
-		0788586517BDFC7100DF0CBD /* AFHTTPClient.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFHTTPClient.m; sourceTree = "<group>"; };
-		0788586617BDFC7100DF0CBD /* AFHTTPRequestOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFHTTPRequestOperation.h; sourceTree = "<group>"; };
-		0788586717BDFC7100DF0CBD /* AFHTTPRequestOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFHTTPRequestOperation.m; sourceTree = "<group>"; };
-		0788586817BDFC7100DF0CBD /* AFImageRequestOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFImageRequestOperation.h; sourceTree = "<group>"; };
-		0788586917BDFC7100DF0CBD /* AFImageRequestOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFImageRequestOperation.m; sourceTree = "<group>"; };
-		0788586A17BDFC7100DF0CBD /* AFJSONRequestOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFJSONRequestOperation.h; sourceTree = "<group>"; };
-		0788586B17BDFC7100DF0CBD /* AFJSONRequestOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFJSONRequestOperation.m; sourceTree = "<group>"; };
-		0788586C17BDFC7100DF0CBD /* AFNetworkActivityIndicatorManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFNetworkActivityIndicatorManager.h; sourceTree = "<group>"; };
-		0788586D17BDFC7100DF0CBD /* AFNetworkActivityIndicatorManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFNetworkActivityIndicatorManager.m; sourceTree = "<group>"; };
-		0788586E17BDFC7100DF0CBD /* AFNetworking.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFNetworking.h; sourceTree = "<group>"; };
-		0788586F17BDFC7100DF0CBD /* AFPropertyListRequestOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFPropertyListRequestOperation.h; sourceTree = "<group>"; };
-		0788587017BDFC7100DF0CBD /* AFPropertyListRequestOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFPropertyListRequestOperation.m; sourceTree = "<group>"; };
-		0788587117BDFC7100DF0CBD /* AFURLConnectionOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFURLConnectionOperation.h; sourceTree = "<group>"; };
-		0788587217BDFC7100DF0CBD /* AFURLConnectionOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFURLConnectionOperation.m; sourceTree = "<group>"; };
-		0788587317BDFC7100DF0CBD /* AFXMLRequestOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFXMLRequestOperation.h; sourceTree = "<group>"; };
-		0788587417BDFC7100DF0CBD /* AFXMLRequestOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFXMLRequestOperation.m; sourceTree = "<group>"; };
-		0788587517BDFC7100DF0CBD /* UIImageView+AFNetworking.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIImageView+AFNetworking.h"; sourceTree = "<group>"; };
-		0788587617BDFC7100DF0CBD /* UIImageView+AFNetworking.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIImageView+AFNetworking.m"; sourceTree = "<group>"; };
 		0788588117BDFC7F00DF0CBD /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = README.md; sourceTree = "<group>"; };
 		0788588317BDFC7F00DF0CBD /* SFHFKeychainUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SFHFKeychainUtils.h; sourceTree = "<group>"; };
 		0788588417BDFC7F00DF0CBD /* SFHFKeychainUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SFHFKeychainUtils.m; sourceTree = "<group>"; };
@@ -502,6 +483,25 @@
 		0788589917BDFD9E00DF0CBD /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
 		0788589B17BDFDA700DF0CBD /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
 		0788589D17BDFDAD00DF0CBD /* MobileCoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MobileCoreServices.framework; path = System/Library/Frameworks/MobileCoreServices.framework; sourceTree = SDKROOT; };
+		099A4BE718E02FBC0085DD25 /* HatenaAFHTTPClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HatenaAFHTTPClient.h; sourceTree = "<group>"; };
+		099A4BE818E02FBC0085DD25 /* HatenaAFHTTPClient.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HatenaAFHTTPClient.m; sourceTree = "<group>"; };
+		099A4BE918E02FBC0085DD25 /* HatenaAFHTTPRequestOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HatenaAFHTTPRequestOperation.h; sourceTree = "<group>"; };
+		099A4BEA18E02FBC0085DD25 /* HatenaAFHTTPRequestOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HatenaAFHTTPRequestOperation.m; sourceTree = "<group>"; };
+		099A4BEB18E02FBC0085DD25 /* HatenaAFImageRequestOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HatenaAFImageRequestOperation.h; sourceTree = "<group>"; };
+		099A4BEC18E02FBC0085DD25 /* HatenaAFImageRequestOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HatenaAFImageRequestOperation.m; sourceTree = "<group>"; };
+		099A4BED18E02FBC0085DD25 /* HatenaAFJSONRequestOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HatenaAFJSONRequestOperation.h; sourceTree = "<group>"; };
+		099A4BEE18E02FBC0085DD25 /* HatenaAFJSONRequestOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HatenaAFJSONRequestOperation.m; sourceTree = "<group>"; };
+		099A4BEF18E02FBC0085DD25 /* HatenaAFNetworkActivityIndicatorManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HatenaAFNetworkActivityIndicatorManager.h; sourceTree = "<group>"; };
+		099A4BF018E02FBC0085DD25 /* HatenaAFNetworkActivityIndicatorManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HatenaAFNetworkActivityIndicatorManager.m; sourceTree = "<group>"; };
+		099A4BF118E02FBC0085DD25 /* HatenaAFNetworking.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HatenaAFNetworking.h; sourceTree = "<group>"; };
+		099A4BF218E02FBC0085DD25 /* HatenaAFPropertyListRequestOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HatenaAFPropertyListRequestOperation.h; sourceTree = "<group>"; };
+		099A4BF318E02FBC0085DD25 /* HatenaAFPropertyListRequestOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HatenaAFPropertyListRequestOperation.m; sourceTree = "<group>"; };
+		099A4BF418E02FBC0085DD25 /* HatenaAFURLConnectionOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HatenaAFURLConnectionOperation.h; sourceTree = "<group>"; };
+		099A4BF518E02FBC0085DD25 /* HatenaAFURLConnectionOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HatenaAFURLConnectionOperation.m; sourceTree = "<group>"; };
+		099A4BF618E02FBC0085DD25 /* HatenaAFXMLRequestOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HatenaAFXMLRequestOperation.h; sourceTree = "<group>"; };
+		099A4BF718E02FBC0085DD25 /* HatenaAFXMLRequestOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HatenaAFXMLRequestOperation.m; sourceTree = "<group>"; };
+		099A4BF818E02FBC0085DD25 /* UIImageView+HatenaAFNetworking.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIImageView+HatenaAFNetworking.h"; sourceTree = "<group>"; };
+		099A4BF918E02FBC0085DD25 /* UIImageView+HatenaAFNetworking.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIImageView+HatenaAFNetworking.m"; sourceTree = "<group>"; };
 		1AB89132E53059069E2DCBF2 /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		1AB896AC125555E365AEE6F8 /* HTBAuthorizeEntry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HTBAuthorizeEntry.h; sourceTree = "<group>"; };
 		1AB89A9AA4B98C05BD475DCC /* HTBAuthorizeEntry.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HTBAuthorizeEntry.m; sourceTree = "<group>"; };
@@ -566,7 +566,6 @@
 			isa = PBXGroup;
 			children = (
 				0788588017BDFC7F00DF0CBD /* scifihifi-iphone */,
-				0788586317BDFC7100DF0CBD /* AFNetworking */,
 				078857B217BDFC2300DF0CBD /* Nocilla */,
 				078856AB17BDFC1400DF0CBD /* Kiwi */,
 				0788559C17BDFA2800DF0CBD /* Spec */,
@@ -1030,6 +1029,7 @@
 				0788580817BDFC5300DF0CBD /* HTBAFOAuth1Client.m */,
 				0788580917BDFC5300DF0CBD /* HTBHatenaBookmarkAPIClient.h */,
 				0788580A17BDFC5300DF0CBD /* HTBHatenaBookmarkAPIClient.m */,
+				099A4BE618E02FBC0085DD25 /* AFNetworking */,
 			);
 			path = API;
 			sourceTree = "<group>";
@@ -1137,33 +1137,6 @@
 			path = ViewController;
 			sourceTree = "<group>";
 		};
-		0788586317BDFC7100DF0CBD /* AFNetworking */ = {
-			isa = PBXGroup;
-			children = (
-				0788586417BDFC7100DF0CBD /* AFHTTPClient.h */,
-				0788586517BDFC7100DF0CBD /* AFHTTPClient.m */,
-				0788586617BDFC7100DF0CBD /* AFHTTPRequestOperation.h */,
-				0788586717BDFC7100DF0CBD /* AFHTTPRequestOperation.m */,
-				0788586817BDFC7100DF0CBD /* AFImageRequestOperation.h */,
-				0788586917BDFC7100DF0CBD /* AFImageRequestOperation.m */,
-				0788586A17BDFC7100DF0CBD /* AFJSONRequestOperation.h */,
-				0788586B17BDFC7100DF0CBD /* AFJSONRequestOperation.m */,
-				0788586C17BDFC7100DF0CBD /* AFNetworkActivityIndicatorManager.h */,
-				0788586D17BDFC7100DF0CBD /* AFNetworkActivityIndicatorManager.m */,
-				0788586E17BDFC7100DF0CBD /* AFNetworking.h */,
-				0788586F17BDFC7100DF0CBD /* AFPropertyListRequestOperation.h */,
-				0788587017BDFC7100DF0CBD /* AFPropertyListRequestOperation.m */,
-				0788587117BDFC7100DF0CBD /* AFURLConnectionOperation.h */,
-				0788587217BDFC7100DF0CBD /* AFURLConnectionOperation.m */,
-				0788587317BDFC7100DF0CBD /* AFXMLRequestOperation.h */,
-				0788587417BDFC7100DF0CBD /* AFXMLRequestOperation.m */,
-				0788587517BDFC7100DF0CBD /* UIImageView+AFNetworking.h */,
-				0788587617BDFC7100DF0CBD /* UIImageView+AFNetworking.m */,
-			);
-			name = AFNetworking;
-			path = ../../AFNetworking/AFNetworking;
-			sourceTree = "<group>";
-		};
 		0788588017BDFC7F00DF0CBD /* scifihifi-iphone */ = {
 			isa = PBXGroup;
 			children = (
@@ -1181,6 +1154,32 @@
 				0788588417BDFC7F00DF0CBD /* SFHFKeychainUtils.m */,
 			);
 			path = security;
+			sourceTree = "<group>";
+		};
+		099A4BE618E02FBC0085DD25 /* AFNetworking */ = {
+			isa = PBXGroup;
+			children = (
+				099A4BE718E02FBC0085DD25 /* HatenaAFHTTPClient.h */,
+				099A4BE818E02FBC0085DD25 /* HatenaAFHTTPClient.m */,
+				099A4BE918E02FBC0085DD25 /* HatenaAFHTTPRequestOperation.h */,
+				099A4BEA18E02FBC0085DD25 /* HatenaAFHTTPRequestOperation.m */,
+				099A4BEB18E02FBC0085DD25 /* HatenaAFImageRequestOperation.h */,
+				099A4BEC18E02FBC0085DD25 /* HatenaAFImageRequestOperation.m */,
+				099A4BED18E02FBC0085DD25 /* HatenaAFJSONRequestOperation.h */,
+				099A4BEE18E02FBC0085DD25 /* HatenaAFJSONRequestOperation.m */,
+				099A4BEF18E02FBC0085DD25 /* HatenaAFNetworkActivityIndicatorManager.h */,
+				099A4BF018E02FBC0085DD25 /* HatenaAFNetworkActivityIndicatorManager.m */,
+				099A4BF118E02FBC0085DD25 /* HatenaAFNetworking.h */,
+				099A4BF218E02FBC0085DD25 /* HatenaAFPropertyListRequestOperation.h */,
+				099A4BF318E02FBC0085DD25 /* HatenaAFPropertyListRequestOperation.m */,
+				099A4BF418E02FBC0085DD25 /* HatenaAFURLConnectionOperation.h */,
+				099A4BF518E02FBC0085DD25 /* HatenaAFURLConnectionOperation.m */,
+				099A4BF618E02FBC0085DD25 /* HatenaAFXMLRequestOperation.h */,
+				099A4BF718E02FBC0085DD25 /* HatenaAFXMLRequestOperation.m */,
+				099A4BF818E02FBC0085DD25 /* UIImageView+HatenaAFNetworking.h */,
+				099A4BF918E02FBC0085DD25 /* UIImageView+HatenaAFNetworking.m */,
+			);
+			path = AFNetworking;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -1268,6 +1267,7 @@
 				078855AA17BDFA2800DF0CBD /* HTBBookmarkedDataEntrySpec.m in Sources */,
 				078855AB17BDFA2800DF0CBD /* HTBBookmarkEntrySpec.m in Sources */,
 				078855AC17BDFA2800DF0CBD /* HTBCanonicalEntrySpec.m in Sources */,
+				099A4C0118E02FBC0085DD25 /* HatenaAFXMLRequestOperation.m in Sources */,
 				078855AD17BDFA2800DF0CBD /* HTBHatenaBookmarkManagerSpec.m in Sources */,
 				078855AE17BDFA2800DF0CBD /* HTBMyEntrySpec.m in Sources */,
 				078855AF17BDFA2800DF0CBD /* HTBTagEntrySpec.m in Sources */,
@@ -1279,6 +1279,7 @@
 				0788576517BDFC1F00DF0CBD /* KWCaptureSpy.m in Sources */,
 				0788576617BDFC1F00DF0CBD /* KWDeviceInfo.m in Sources */,
 				0788576717BDFC1F00DF0CBD /* KWExample.m in Sources */,
+				099A4BFC18E02FBC0085DD25 /* HatenaAFImageRequestOperation.m in Sources */,
 				0788576817BDFC1F00DF0CBD /* KWExampleSuite.m in Sources */,
 				0788576917BDFC1F00DF0CBD /* KWExampleSuiteBuilder.m in Sources */,
 				0788576A17BDFC1F00DF0CBD /* KWFailure.m in Sources */,
@@ -1290,6 +1291,7 @@
 				0788577017BDFC1F00DF0CBD /* KWMatchers.m in Sources */,
 				0788577117BDFC1F00DF0CBD /* KWMessageTracker.m in Sources */,
 				0788577217BDFC1F00DF0CBD /* KWNull.m in Sources */,
+				099A4C0218E02FBC0085DD25 /* UIImageView+HatenaAFNetworking.m in Sources */,
 				0788577317BDFC1F00DF0CBD /* KWObjCUtilities.m in Sources */,
 				0788577417BDFC1F00DF0CBD /* KWProbePoller.m in Sources */,
 				0788577517BDFC1F00DF0CBD /* KWSpec.m in Sources */,
@@ -1300,6 +1302,7 @@
 				0788577A17BDFC1F00DF0CBD /* NSInvocation+OCMAdditions.m in Sources */,
 				0788577B17BDFC1F00DF0CBD /* NSMethodSignature+KiwiAdditions.m in Sources */,
 				0788577C17BDFC1F00DF0CBD /* NSNumber+KiwiAdditions.m in Sources */,
+				099A4BFF18E02FBC0085DD25 /* HatenaAFPropertyListRequestOperation.m in Sources */,
 				0788577D17BDFC1F00DF0CBD /* NSObject+KiwiSpyAdditions.m in Sources */,
 				0788577E17BDFC1F00DF0CBD /* NSObject+KiwiVerifierAdditions.m in Sources */,
 				0788577F17BDFC1F00DF0CBD /* NSProxy+KiwiVerifierAdditions.m in Sources */,
@@ -1307,6 +1310,7 @@
 				0788578117BDFC1F00DF0CBD /* SenTestSuite+KiwiAdditions.m in Sources */,
 				0788578217BDFC1F00DF0CBD /* KWBeBetweenMatcher.m in Sources */,
 				0788578317BDFC1F00DF0CBD /* KWBeEmptyMatcher.m in Sources */,
+				099A4BFB18E02FBC0085DD25 /* HatenaAFHTTPRequestOperation.m in Sources */,
 				0788578417BDFC1F00DF0CBD /* KWBeIdenticalToMatcher.m in Sources */,
 				0788578517BDFC1F00DF0CBD /* KWBeKindOfClassMatcher.m in Sources */,
 				0788578617BDFC1F00DF0CBD /* KWBeMemberOfClassMatcher.m in Sources */,
@@ -1323,6 +1327,7 @@
 				0788579117BDFC1F00DF0CBD /* KWGenericMatcher.m in Sources */,
 				0788579217BDFC1F00DF0CBD /* KWGenericMatchEvaluator.m in Sources */,
 				0788579317BDFC1F00DF0CBD /* KWGenericMatchingAdditions.m in Sources */,
+				099A4C0018E02FBC0085DD25 /* HatenaAFURLConnectionOperation.m in Sources */,
 				0788579417BDFC1F00DF0CBD /* KWHaveMatcher.m in Sources */,
 				0788579517BDFC1F00DF0CBD /* KWHaveValueMatcher.m in Sources */,
 				0788579617BDFC1F00DF0CBD /* KWInequalityMatcher.m in Sources */,
@@ -1337,6 +1342,7 @@
 				0788579F17BDFC1F00DF0CBD /* KWMock.m in Sources */,
 				078857A017BDFC1F00DF0CBD /* NSObject+KiwiMockAdditions.m in Sources */,
 				078857A117BDFC1F00DF0CBD /* KWAfterAllNode.m in Sources */,
+				099A4BFD18E02FBC0085DD25 /* HatenaAFJSONRequestOperation.m in Sources */,
 				078857A217BDFC1F00DF0CBD /* KWAfterEachNode.m in Sources */,
 				078857A317BDFC1F00DF0CBD /* KWBeforeAllNode.m in Sources */,
 				078857A417BDFC1F00DF0CBD /* KWBeforeEachNode.m in Sources */,
@@ -1374,8 +1380,10 @@
 				0788580117BDFC3200DF0CBD /* NSString+Matcheable.m in Sources */,
 				0788580217BDFC3200DF0CBD /* LSStubRequest.m in Sources */,
 				0788580317BDFC3200DF0CBD /* LSStubResponse.m in Sources */,
+				099A4BFE18E02FBC0085DD25 /* HatenaAFNetworkActivityIndicatorManager.m in Sources */,
 				0788580417BDFC3200DF0CBD /* LSNocilla.m in Sources */,
 				0788584617BDFC5300DF0CBD /* HTBAFOAuth1Client.m in Sources */,
+				099A4BFA18E02FBC0085DD25 /* HatenaAFHTTPClient.m in Sources */,
 				0788584717BDFC5300DF0CBD /* HTBHatenaBookmarkAPIClient.m in Sources */,
 				0788584817BDFC5300DF0CBD /* HTBHatenaBookmarkActivity.m in Sources */,
 				0788584A17BDFC5300DF0CBD /* HTBBookmarkedDataEntry.m in Sources */,
@@ -1403,15 +1411,6 @@
 				0788586017BDFC5300DF0CBD /* HTBCommentViewController.m in Sources */,
 				0788586117BDFC5300DF0CBD /* HTBHatenaBookmarkViewController.m in Sources */,
 				0788586217BDFC5300DF0CBD /* HTBLoginWebViewController.m in Sources */,
-				0788587717BDFC7100DF0CBD /* AFHTTPClient.m in Sources */,
-				0788587817BDFC7100DF0CBD /* AFHTTPRequestOperation.m in Sources */,
-				0788587917BDFC7100DF0CBD /* AFImageRequestOperation.m in Sources */,
-				0788587A17BDFC7100DF0CBD /* AFJSONRequestOperation.m in Sources */,
-				0788587B17BDFC7100DF0CBD /* AFNetworkActivityIndicatorManager.m in Sources */,
-				0788587C17BDFC7100DF0CBD /* AFPropertyListRequestOperation.m in Sources */,
-				0788587D17BDFC7100DF0CBD /* AFURLConnectionOperation.m in Sources */,
-				0788587E17BDFC7100DF0CBD /* AFXMLRequestOperation.m in Sources */,
-				0788587F17BDFC7100DF0CBD /* UIImageView+AFNetworking.m in Sources */,
 				0788588F17BDFC7F00DF0CBD /* SFHFKeychainUtils.m in Sources */,
 				1AB89299C48775FF2B1096DA /* HTBAuthorizeEntry.m in Sources */,
 			);

--- a/HatenaBookmarkSDKTests/Spec/API/HTBHatenaBookmarkAPIClientSpec.m
+++ b/HatenaBookmarkSDKTests/Spec/API/HTBHatenaBookmarkAPIClientSpec.m
@@ -122,9 +122,9 @@ describe(@"HTBHatenaBookmarkAPIClient", ^{
 
             __block id response = nil;
 
-            [client getMyWithSuccess:^(AFHTTPRequestOperation *operation, id responseJSON) {
+            [client getMyWithSuccess:^(HatenaAFHTTPRequestOperation *operation, id responseJSON) {
                 response = responseJSON;
-            } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+            } failure:^(HatenaAFHTTPRequestOperation *operation, NSError *error) {
             }];
             [[expectFutureValue(response) shouldEventually] beNonNil];
         });
@@ -145,9 +145,9 @@ describe(@"HTBHatenaBookmarkAPIClient", ^{
 
             __block HTBMyTagsEntry *myTagsEntry = nil;
 
-            [client getMyTagsWithSuccess:^(AFHTTPRequestOperation *operation, id responseJSON) {
+            [client getMyTagsWithSuccess:^(HatenaAFHTTPRequestOperation *operation, id responseJSON) {
                 myTagsEntry = [[HTBMyTagsEntry alloc] initWithJSON:responseJSON];
-            } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+            } failure:^(HatenaAFHTTPRequestOperation *operation, NSError *error) {
             }];
             [[expectFutureValue(myTagsEntry) shouldEventually] beNonNil];
             [[expectFutureValue(myTagsEntry.tags) shouldEventually] haveCountOf:4];
@@ -175,9 +175,9 @@ describe(@"HTBHatenaBookmarkAPIClient", ^{
                                     comment:@"tag0"
                                        tags:@[@"tag0", @"tag1"]
                                     options:HatenaBookmarkPostOptionTwitter | HatenaBookmarkPostOptionFacebook
-                        success:^(AFHTTPRequestOperation *operation, id responseJSON) {
+                        success:^(HatenaAFHTTPRequestOperation *operation, id responseJSON) {
                             bookmarkedDataEntry = [[HTBBookmarkedDataEntry alloc] initWithJSON:responseJSON];
-                        } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+                        } failure:^(HatenaAFHTTPRequestOperation *operation, NSError *error) {
 
                 }];
                 [[expectFutureValue(bookmarkedDataEntry) shouldEventually] beNonNil];
@@ -199,9 +199,9 @@ describe(@"HTBHatenaBookmarkAPIClient", ^{
                         withHeaders(@{@"Content-Type": @"application/json"}).
                         withBody([[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding]);
 
-                [client getBookmarkWithURL:url success:^(AFHTTPRequestOperation *operation, id responseJSON) {
+                [client getBookmarkWithURL:url success:^(HatenaAFHTTPRequestOperation *operation, id responseJSON) {
                     bookmarkedDataEntry = [[HTBBookmarkedDataEntry alloc] initWithJSON:responseJSON];
-                } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+                } failure:^(HatenaAFHTTPRequestOperation *operation, NSError *error) {
 
                 }];
                 [[expectFutureValue(bookmarkedDataEntry) shouldEventually] beNonNil];
@@ -217,10 +217,10 @@ describe(@"HTBHatenaBookmarkAPIClient", ^{
                         withBody(@"{\"status\" : \"ok\"}");
                 __block id response = nil;
                 [client deleteBookmarkWithURL:url
-                                      success:^(AFHTTPRequestOperation *operation, id responseJSON) {
+                                      success:^(HatenaAFHTTPRequestOperation *operation, id responseJSON) {
                                           response = responseJSON;
                                       }
-                                      failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+                                      failure:^(HatenaAFHTTPRequestOperation *operation, NSError *error) {
 
                                       }];
                 [[expectFutureValue(response) shouldEventually] beNonNil];
@@ -249,9 +249,9 @@ describe(@"HTBHatenaBookmarkAPIClient", ^{
                         withBody([[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding]);
 
                 __block HTBBookmarkEntry *bookmarkEntry = nil;
-                [client getEntryWithURL:url success:^(AFHTTPRequestOperation *operation, id responseJSON) {
+                [client getEntryWithURL:url success:^(HatenaAFHTTPRequestOperation *operation, id responseJSON) {
                     bookmarkEntry = [[HTBBookmarkEntry alloc] initWithJSON:responseJSON];
-                } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+                } failure:^(HatenaAFHTTPRequestOperation *operation, NSError *error) {
 
                 }];
                 [[expectFutureValue(bookmarkEntry) shouldEventually] beNonNil];
@@ -279,9 +279,9 @@ describe(@"HTBHatenaBookmarkAPIClient", ^{
                         withBody([[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding]);
 
                 __block HTBCanonicalEntry *canonicalEntry = nil;
-                [client getCanonicalEntryWithURL:url success:^(AFHTTPRequestOperation *operation, id responseJSON) {
+                [client getCanonicalEntryWithURL:url success:^(HatenaAFHTTPRequestOperation *operation, id responseJSON) {
                     canonicalEntry = [[HTBCanonicalEntry alloc] initWithJSON:responseJSON];
-                } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+                } failure:^(HatenaAFHTTPRequestOperation *operation, NSError *error) {
 
                 }];
                 [[expectFutureValue(canonicalEntry) shouldEventually] beNonNil];

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Clone this repository.
 git clone --recursive https://github.com/hatena/Hatena-Bookmark-iOS-SDK.git
 ```
 
-Copy `/SDK/` directory and add dependent modules [AFNetworking](https://github.com/AFNetworking/AFNetworking) and [SFHFKeychainUtils](https://github.com/ldandersen/scifihifi-iphone/) to your project .
+Copy `/SDK/` directory and add dependent modules [SFHFKeychainUtils](https://github.com/ldandersen/scifihifi-iphone/) to your project .
 
 # Usage
 
@@ -173,7 +173,7 @@ Clone this repository and run `make clean test` in root directory.
 ## Dependency
 - [AFNetworking](https://github.com/AFNetworking/AFNetworking)
  - Version 1.x
- - Currently 2.0 is not supported because it required iOS 7.
+ - Currently 2.0 is not supported because it required iOS 7 and we included renamed AFNetworking 1.x.
 - [AFOAuth1Client](https://github.com/AFNetworking/AFOAuth1Client)
  - Currentry we forked and copied it as HTBAFOAuth1Client for waiting merge some pull requests.
 - [SFHFKeychainUtils](https://github.com/ldandersen/scifihifi-iphone/)

--- a/SDK/API/AFNetworking/HatenaAFHTTPClient.h
+++ b/SDK/API/AFNetworking/HatenaAFHTTPClient.h
@@ -1,0 +1,641 @@
+// HatenaAFHTTPClient.h
+//
+// Copyright (c) 2011 Gowalla (http://gowalla.com/)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <Foundation/Foundation.h>
+#import "HatenaAFURLConnectionOperation.h"
+
+#import <Availability.h>
+
+/**
+ `HatenaAFHTTPClient` captures the common patterns of communicating with an web application over HTTP. It encapsulates information like base URL, authorization credentials, and HTTP headers, and uses them to construct and manage the execution of HTTP request operations.
+
+ ## Automatic Content Parsing
+
+ Instances of `HatenaAFHTTPClient` may specify which types of requests it expects and should handle by registering HTTP operation classes for automatic parsing. Registered classes will determine whether they can handle a particular request, and then construct a request operation accordingly in `enqueueHTTPRequestOperationWithRequest:success:failure`.
+
+ ## Subclassing Notes
+
+ In most cases, one should create an `HatenaAFHTTPClient` subclass for each website or web application that your application communicates with. It is often useful, also, to define a class method that returns a singleton shared HTTP client in each subclass, that persists authentication credentials and other configuration across the entire application.
+
+ ## Methods to Override
+
+ To change the behavior of all url request construction for an `HatenaAFHTTPClient` subclass, override `requestWithMethod:path:parameters`.
+
+ To change the behavior of all request operation construction for an `HatenaAFHTTPClient` subclass, override `HTTPRequestOperationWithRequest:success:failure`.
+
+ ## Default Headers
+
+ By default, `HatenaAFHTTPClient` sets the following HTTP headers:
+
+ - `Accept-Language: (comma-delimited preferred languages), en-us;q=0.8`
+ - `User-Agent: (generated user agent)`
+
+ You can override these HTTP headers or define new ones using `setDefaultHeader:value:`.
+
+ ## URL Construction Using Relative Paths
+
+ Both `-requestWithMethod:path:parameters:` and `-multipartFormRequestWithMethod:path:parameters:constructingBodyWithBlock:` construct URLs from the path relative to the `-baseURL`, using `NSURL +URLWithString:relativeToURL:`. Below are a few examples of how `baseURL` and relative paths interact:
+
+    NSURL *baseURL = [NSURL URLWithString:@"http://example.com/v1/"];
+    [NSURL URLWithString:@"foo" relativeToURL:baseURL];                  // http://example.com/v1/foo
+    [NSURL URLWithString:@"foo?bar=baz" relativeToURL:baseURL];          // http://example.com/v1/foo?bar=baz
+    [NSURL URLWithString:@"/foo" relativeToURL:baseURL];                 // http://example.com/foo
+    [NSURL URLWithString:@"foo/" relativeToURL:baseURL];                 // http://example.com/v1/foo
+    [NSURL URLWithString:@"/foo/" relativeToURL:baseURL];                // http://example.com/foo/
+    [NSURL URLWithString:@"http://example2.com/" relativeToURL:baseURL]; // http://example2.com/
+
+ Also important to note is that a trailing slash will be added to any `baseURL` without one, which would otherwise cause unexpected behavior when constructing URLs using paths without a leading slash.
+
+ ## NSCoding / NSCopying Conformance
+
+ `HatenaAFHTTPClient`  conforms to the `NSCoding` and `NSCopying` protocols, allowing operations to be archived to disk, and copied in memory, respectively. There are a few minor caveats to keep in mind, however:
+
+ - Archives and copies of HTTP clients will be initialized with an empty operation queue.
+ - NSCoding cannot serialize / deserialize block properties, so an archive of an HTTP client will not include any reachability callback block that may be set.
+ */
+
+#ifdef _SYSTEMCONFIGURATION_H
+typedef enum {
+    HatenaAFNetworkReachabilityStatusUnknown          = -1,
+    HatenaAFNetworkReachabilityStatusNotReachable     = 0,
+    HatenaAFNetworkReachabilityStatusReachableViaWWAN = 1,
+    HatenaAFNetworkReachabilityStatusReachableViaWiFi = 2,
+} HatenaAFNetworkReachabilityStatus;
+#else
+#pragma message("SystemConfiguration framework not found in project, or not included in precompiled header. Network reachability functionality will not be available.")
+#endif
+
+#ifndef __UTTYPE__
+#if __IPHONE_OS_VERSION_MIN_REQUIRED
+#pragma message("MobileCoreServices framework not found in project, or not included in precompiled header. Automatic MIME type detection when uploading files in multipart requests will not be available.")
+#else
+#pragma message("CoreServices framework not found in project, or not included in precompiled header. Automatic MIME type detection when uploading files in multipart requests will not be available.")
+#endif
+#endif
+
+typedef enum {
+    HatenaAFFormURLParameterEncoding,
+    HatenaAFJSONParameterEncoding,
+    HatenaAFPropertyListParameterEncoding,
+} HatenaAFHTTPClientParameterEncoding;
+
+@class HatenaAFHTTPRequestOperation;
+@protocol HatenaAFMultipartFormData;
+
+@interface HatenaAFHTTPClient : NSObject <NSCoding, NSCopying>
+
+///---------------------------------------
+/// @name Accessing HTTP Client Properties
+///---------------------------------------
+
+/**
+ The url used as the base for paths specified in methods such as `getPath:parameters:success:failure`
+ */
+@property (readonly, nonatomic, strong) NSURL *baseURL;
+
+/**
+ The string encoding used in constructing url requests. This is `NSUTF8StringEncoding` by default.
+ */
+@property (nonatomic, assign) NSStringEncoding stringEncoding;
+
+/**
+ The `HatenaAFHTTPClientParameterEncoding` value corresponding to how parameters are encoded into a request body for request methods other than `GET`, `HEAD` or `DELETE`. This is `HatenaAFFormURLParameterEncoding` by default.
+
+ @warning Some nested parameter structures, such as a keyed array of hashes containing inconsistent keys (i.e. `@{@"": @[@{@"a" : @(1)}, @{@"b" : @(2)}]}`), cannot be unambiguously represented in query strings. It is strongly recommended that an unambiguous encoding, such as `HatenaAFJSONParameterEncoding`, is used when posting complicated or nondeterministic parameter structures.
+ */
+@property (nonatomic, assign) HatenaAFHTTPClientParameterEncoding parameterEncoding;
+
+/**
+ The operation queue which manages operations enqueued by the HTTP client.
+ */
+@property (readonly, nonatomic, strong) NSOperationQueue *operationQueue;
+
+/**
+ The reachability status from the device to the current `baseURL` of the `HatenaAFHTTPClient`.
+
+ @warning This property requires the `SystemConfiguration` framework. Add it in the active target's "Link Binary With Library" build phase, and add `#import <SystemConfiguration/SystemConfiguration.h>` to the header prefix of the project (`Prefix.pch`).
+ */
+#ifdef _SYSTEMCONFIGURATION_H
+@property (readonly, nonatomic, assign) HatenaAFNetworkReachabilityStatus networkReachabilityStatus;
+#endif
+
+/**
+ Default SSL pinning mode for each `HatenaAFHTTPRequestOperation` created by `HTTPRequestOperationWithRequest:success:failure:`.
+ */
+@property (nonatomic, assign) HatenaAFURLConnectionOperationSSLPinningMode defaultSSLPinningMode;
+
+/**
+ Whether each `HatenaAFHTTPRequestOperation` created by `HTTPRequestOperationWithRequest:success:failure:` should accept an invalid SSL certificate. 
+ 
+ If `_HatenaAFNETWORKING_ALLOW_INVALID_SSL_CERTIFICATES_` is set, this property defaults to `YES` for backwards compatibility. Otherwise, this property defaults to `NO`.
+ */
+@property (nonatomic, assign) BOOL allowsInvalidSSLCertificate;
+
+///---------------------------------------------
+/// @name Creating and Initializing HTTP Clients
+///---------------------------------------------
+
+/**
+ Creates and initializes an `HatenaAFHTTPClient` object with the specified base URL.
+
+ @param url The base URL for the HTTP client. This argument must not be `nil`.
+
+ @return The newly-initialized HTTP client
+ */
++ (instancetype)clientWithBaseURL:(NSURL *)url;
+
+/**
+ Initializes an `HatenaAFHTTPClient` object with the specified base URL.
+ 
+ This is the designated initializer.
+
+ @param url The base URL for the HTTP client. This argument must not be `nil`.
+
+ @return The newly-initialized HTTP client
+ */
+- (id)initWithBaseURL:(NSURL *)url;
+
+///-----------------------------------
+/// @name Managing Reachability Status
+///-----------------------------------
+
+/**
+ Sets a callback to be executed when the network availability of the `baseURL` host changes.
+
+ @param block A block object to be executed when the network availability of the `baseURL` host changes.. This block has no return value and takes a single argument which represents the various reachability states from the device to the `baseURL`.
+
+ @warning This method requires the `SystemConfiguration` framework. Add it in the active target's "Link Binary With Library" build phase, and add `#import <SystemConfiguration/SystemConfiguration.h>` to the header prefix of the project (`Prefix.pch`).
+ */
+#ifdef _SYSTEMCONFIGURATION_H
+- (void)setReachabilityStatusChangeBlock:(void (^)(HatenaAFNetworkReachabilityStatus status))block;
+#endif
+
+///-------------------------------
+/// @name Managing HTTP Operations
+///-------------------------------
+
+/**
+ Attempts to register a subclass of `HatenaAFHTTPRequestOperation`, adding it to a chain to automatically generate request operations from a URL request.
+
+ When `enqueueHTTPRequestOperationWithRequest:success:failure` is invoked, each registered class is consulted in turn to see if it can handle the specific request. The first class to return `YES` when sent a `canProcessRequest:` message is used to create an operation using `initWithURLRequest:` and do `setCompletionBlockWithSuccess:failure:`. There is no guarantee that all registered classes will be consulted. Classes are consulted in the reverse order of their registration. Attempting to register an already-registered class will move it to the top of the list.
+ 
+ @param operationClass The subclass of `HatenaAFHTTPRequestOperation` to register
+
+ @return `YES` if the registration is successful, `NO` otherwise. The only failure condition is if `operationClass` is not a subclass of `HatenaAFHTTPRequestOperation`.
+ */
+- (BOOL)registerHTTPOperationClass:(Class)operationClass;
+
+/**
+ Unregisters the specified subclass of `HatenaAFHTTPRequestOperation` from the chain of classes consulted when `-requestWithMethod:path:parameters` is called.
+
+ @param operationClass The subclass of `HatenaAFHTTPRequestOperation` to register
+ */
+- (void)unregisterHTTPOperationClass:(Class)operationClass;
+
+///----------------------------------
+/// @name Managing HTTP Header Values
+///----------------------------------
+
+/**
+ Returns the value for the HTTP headers set in request objects created by the HTTP client.
+
+ @param header The HTTP header to return the default value for
+
+ @return The default value for the HTTP header, or `nil` if unspecified
+ */
+- (NSString *)defaultValueForHeader:(NSString *)header;
+
+/**
+ Sets the value for the HTTP headers set in request objects made by the HTTP client. If `nil`, removes the existing value for that header.
+
+ @param header The HTTP header to set a default value for
+ @param value The value set as default for the specified header, or `nil
+ */
+- (void)setDefaultHeader:(NSString *)header
+                   value:(NSString *)value;
+
+/**
+ Sets the "Authorization" HTTP header set in request objects made by the HTTP client to a basic authentication value with Base64-encoded username and password. This overwrites any existing value for this header.
+
+ @param username The HTTP basic auth username
+ @param password The HTTP basic auth password
+ */
+- (void)setAuthorizationHeaderWithUsername:(NSString *)username
+                                  password:(NSString *)password;
+
+/**
+ Sets the "Authorization" HTTP header set in request objects made by the HTTP client to a token-based authentication value, such as an OAuth access token. This overwrites any existing value for this header.
+
+ @param token The authentication token
+ */
+- (void)setAuthorizationHeaderWithToken:(NSString *)token;
+
+
+/**
+ Clears any existing value for the "Authorization" HTTP header.
+ */
+- (void)clearAuthorizationHeader;
+
+///-------------------------------
+/// @name Managing URL Credentials
+///-------------------------------
+
+/**
+ Set the default URL credential to be set for request operations.
+
+ @param credential The URL credential
+ */
+- (void)setDefaultCredential:(NSURLCredential *)credential;
+
+///-------------------------------
+/// @name Creating Request Objects
+///-------------------------------
+
+/**
+ Creates an `NSMutableURLRequest` object with the specified HTTP method and path.
+
+ If the HTTP method is `GET`, `HEAD`, or `DELETE`, the parameters will be used to construct a url-encoded query string that is appended to the request's URL. Otherwise, the parameters will be encoded according to the value of the `parameterEncoding` property, and set as the request body.
+
+ @param method The HTTP method for the request, such as `GET`, `POST`, `PUT`, or `DELETE`. This parameter must not be `nil`.
+ @param path The path to be appended to the HTTP client's base URL and used as the request URL. If `nil`, no path will be appended to the base URL.
+ @param parameters The parameters to be either set as a query string for `GET` requests, or the request HTTP body.
+
+ @return An `NSMutableURLRequest` object
+ */
+- (NSMutableURLRequest *)requestWithMethod:(NSString *)method
+                                      path:(NSString *)path
+                                parameters:(NSDictionary *)parameters;
+
+/**
+ Creates an `NSMutableURLRequest` object with the specified HTTP method and path, and constructs a `multipart/form-data` HTTP body, using the specified parameters and multipart form data block. See http://www.w3.org/TR/html4/interact/forms.html#h-17.13.4.2
+
+ Multipart form requests are automatically streamed, reading files directly from disk along with in-memory data in a single HTTP body. The resulting `NSMutableURLRequest` object has an `HTTPBodyStream` property, so refrain from setting `HTTPBodyStream` or `HTTPBody` on this request object, as it will clear out the multipart form body stream.
+ 
+ @param method The HTTP method for the request. This parameter must not be `GET` or `HEAD`, or `nil`.
+ @param path The path to be appended to the HTTP client's base URL and used as the request URL.
+ @param parameters The parameters to be encoded and set in the request HTTP body.
+ @param block A block that takes a single argument and appends data to the HTTP body. The block argument is an object adopting the `HatenaAFMultipartFormData` protocol. This can be used to upload files, encode HTTP body as JSON or XML, or specify multiple values for the same parameter, as one might for array values.
+
+ @return An `NSMutableURLRequest` object
+ */
+- (NSMutableURLRequest *)multipartFormRequestWithMethod:(NSString *)method
+                                                   path:(NSString *)path
+                                             parameters:(NSDictionary *)parameters
+                              constructingBodyWithBlock:(void (^)(id <HatenaAFMultipartFormData> formData))block;
+
+///-------------------------------
+/// @name Creating HTTP Operations
+///-------------------------------
+
+/**
+ Creates an `HatenaAFHTTPRequestOperation`.
+
+ In order to determine what kind of operation is created, each registered subclass conforming to the `HatenaAFHTTPClient` protocol is consulted (in reverse order of when they were specified) to see if it can handle the specific request. The first class to return `YES` when sent a `canProcessRequest:` message is used to generate an operation using `HTTPRequestOperationWithRequest:success:failure:`.
+
+ @param urlRequest The request object to be loaded asynchronously during execution of the operation.
+ @param success A block object to be executed when the request operation finishes successfully. This block has no return value and takes two arguments: the created request operation and the object created from the response data of request.
+ @param failure A block object to be executed when the request operation finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the response data. This block has no return value and takes two arguments:, the created request operation and the `NSError` object describing the network or parsing error that occurred.
+ */
+- (HatenaAFHTTPRequestOperation *)HTTPRequestOperationWithRequest:(NSURLRequest *)urlRequest
+                                                    success:(void (^)(HatenaAFHTTPRequestOperation *operation, id responseObject))success
+                                                    failure:(void (^)(HatenaAFHTTPRequestOperation *operation, NSError *error))failure;
+
+///----------------------------------------
+/// @name Managing Enqueued HTTP Operations
+///----------------------------------------
+
+/**
+ Enqueues an `HatenaAFHTTPRequestOperation` to the HTTP client's operation queue.
+
+ @param operation The HTTP request operation to be enqueued.
+ */
+- (void)enqueueHTTPRequestOperation:(HatenaAFHTTPRequestOperation *)operation;
+
+/**
+ Cancels all operations in the HTTP client's operation queue whose URLs match the specified HTTP method and path.
+ 
+ This method only cancels `HatenaAFHTTPRequestOperations` whose request URL matches the HTTP client base URL with the path appended. For complete control over the lifecycle of enqueued operations, you can access the `operationQueue` property directly, which allows you to, for instance, cancel operations filtered by a predicate, or simply use `-cancelAllRequests`. Note that the operation queue may include non-HTTP operations, so be sure to check the type before attempting to directly introspect an operation's `request` property.
+
+ @param method The HTTP method to match for the cancelled requests, such as `GET`, `POST`, `PUT`, or `DELETE`. If `nil`, all request operations with URLs matching the path will be cancelled.
+ @param path The path appended to the HTTP client base URL to match against the cancelled requests. If `nil`, no path will be appended to the base URL.
+ */
+- (void)cancelAllHTTPOperationsWithMethod:(NSString *)method path:(NSString *)path;
+
+///---------------------------------------
+/// @name Batching HTTP Request Operations
+///---------------------------------------
+
+/**
+ Creates and enqueues an `HatenaAFHTTPRequestOperation` to the HTTP client's operation queue for each specified request object into a batch. When each request operation finishes, the specified progress block is executed, until all of the request operations have finished, at which point the completion block also executes.
+
+ Operations are created by passing the specified `NSURLRequest` objects in `requests`, using `-HTTPRequestOperationWithRequest:success:failure:`, with `nil` for both the `success` and `failure` parameters.
+ 
+ @param urlRequests The `NSURLRequest` objects used to create and enqueue operations.
+ @param progressBlock A block object to be executed upon the completion of each request operation in the batch. This block has no return value and takes two arguments: the number of operations that have already finished execution, and the total number of operations.
+ @param completionBlock A block object to be executed upon the completion of all of the request operations in the batch. This block has no return value and takes a single argument: the batched request operations.
+ */
+- (void)enqueueBatchOfHTTPRequestOperationsWithRequests:(NSArray *)urlRequests
+                                          progressBlock:(void (^)(NSUInteger numberOfFinishedOperations, NSUInteger totalNumberOfOperations))progressBlock
+                                        completionBlock:(void (^)(NSArray *operations))completionBlock;
+
+/**
+ Enqueues the specified request operations into a batch. When each request operation finishes, the specified progress block is executed, until all of the request operations have finished, at which point the completion block also executes.
+
+ @param operations The request operations used to be batched and enqueued.
+ @param progressBlock A block object to be executed upon the completion of each request operation in the batch. This block has no return value and takes two arguments: the number of operations that have already finished execution, and the total number of operations.
+ @param completionBlock A block object to be executed upon the completion of all of the request operations in the batch. This block has no return value and takes a single argument: the batched request operations.
+ */
+- (void)enqueueBatchOfHTTPRequestOperations:(NSArray *)operations
+                              progressBlock:(void (^)(NSUInteger numberOfFinishedOperations, NSUInteger totalNumberOfOperations))progressBlock
+                            completionBlock:(void (^)(NSArray *operations))completionBlock;
+
+///---------------------------
+/// @name Making HTTP Requests
+///---------------------------
+
+/**
+ Creates an `HatenaAFHTTPRequestOperation` with a `GET` request, and enqueues it to the HTTP client's operation queue.
+
+ @param path The path to be appended to the HTTP client's base URL and used as the request URL.
+ @param parameters The parameters to be encoded and appended as the query string for the request URL.
+ @param success A block object to be executed when the request operation finishes successfully. This block has no return value and takes two arguments: the created request operation and the object created from the response data of request.
+ @param failure A block object to be executed when the request operation finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the response data. This block has no return value and takes two arguments: the created request operation and the `NSError` object describing the network or parsing error that occurred.
+
+ @see -HTTPRequestOperationWithRequest:success:failure:
+ */
+- (void)getPath:(NSString *)path
+     parameters:(NSDictionary *)parameters
+        success:(void (^)(HatenaAFHTTPRequestOperation *operation, id responseObject))success
+        failure:(void (^)(HatenaAFHTTPRequestOperation *operation, NSError *error))failure;
+
+/**
+ Creates an `HatenaAFHTTPRequestOperation` with a `POST` request, and enqueues it to the HTTP client's operation queue.
+
+ @param path The path to be appended to the HTTP client's base URL and used as the request URL.
+ @param parameters The parameters to be encoded and set in the request HTTP body.
+ @param success A block object to be executed when the request operation finishes successfully. This block has no return value and takes two arguments: the created request operation and the object created from the response data of request.
+ @param failure A block object to be executed when the request operation finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the response data. This block has no return value and takes two arguments: the created request operation and the `NSError` object describing the network or parsing error that occurred.
+
+ @see -HTTPRequestOperationWithRequest:success:failure:
+ */
+- (void)postPath:(NSString *)path
+      parameters:(NSDictionary *)parameters
+         success:(void (^)(HatenaAFHTTPRequestOperation *operation, id responseObject))success
+         failure:(void (^)(HatenaAFHTTPRequestOperation *operation, NSError *error))failure;
+
+/**
+ Creates an `HatenaAFHTTPRequestOperation` with a `PUT` request, and enqueues it to the HTTP client's operation queue.
+
+ @param path The path to be appended to the HTTP client's base URL and used as the request URL.
+ @param parameters The parameters to be encoded and set in the request HTTP body.
+ @param success A block object to be executed when the request operation finishes successfully. This block has no return value and takes two arguments: the created request operation and the object created from the response data of request.
+ @param failure A block object to be executed when the request operation finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the response data. This block has no return value and takes two arguments: the created request operation and the `NSError` object describing the network or parsing error that occurred.
+
+ @see -HTTPRequestOperationWithRequest:success:failure:
+ */
+- (void)putPath:(NSString *)path
+     parameters:(NSDictionary *)parameters
+        success:(void (^)(HatenaAFHTTPRequestOperation *operation, id responseObject))success
+        failure:(void (^)(HatenaAFHTTPRequestOperation *operation, NSError *error))failure;
+
+/**
+ Creates an `HatenaAFHTTPRequestOperation` with a `DELETE` request, and enqueues it to the HTTP client's operation queue.
+
+ @param path The path to be appended to the HTTP client's base URL and used as the request URL.
+ @param parameters The parameters to be encoded and appended as the query string for the request URL.
+ @param success A block object to be executed when the request operation finishes successfully. This block has no return value and takes two arguments: the created request operation and the object created from the response data of request.
+ @param failure A block object to be executed when the request operation finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the response data. This block has no return value and takes two arguments: the created request operation and the `NSError` object describing the network or parsing error that occurred.
+
+ @see -HTTPRequestOperationWithRequest:success:failure:
+ */
+- (void)deletePath:(NSString *)path
+        parameters:(NSDictionary *)parameters
+           success:(void (^)(HatenaAFHTTPRequestOperation *operation, id responseObject))success
+           failure:(void (^)(HatenaAFHTTPRequestOperation *operation, NSError *error))failure;
+
+/**
+ Creates an `HatenaAFHTTPRequestOperation` with a `PATCH` request, and enqueues it to the HTTP client's operation queue.
+
+ @param path The path to be appended to the HTTP client's base URL and used as the request URL.
+ @param parameters The parameters to be encoded and set in the request HTTP body.
+ @param success A block object to be executed when the request operation finishes successfully. This block has no return value and takes two arguments: the created request operation and the object created from the response data of request.
+ @param failure A block object to be executed when the request operation finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the response data. This block has no return value and takes two arguments: the created request operation and the `NSError` object describing the network or parsing error that occurred.
+
+ @see -HTTPRequestOperationWithRequest:success:failure:
+ */
+- (void)patchPath:(NSString *)path
+       parameters:(NSDictionary *)parameters
+          success:(void (^)(HatenaAFHTTPRequestOperation *operation, id responseObject))success
+          failure:(void (^)(HatenaAFHTTPRequestOperation *operation, NSError *error))failure;
+@end
+
+///----------------
+/// @name Constants
+///----------------
+
+/**
+ ## Network Reachability
+
+ The following constants are provided by `HatenaAFHTTPClient` as possible network reachability statuses.
+
+ enum {
+ HatenaAFNetworkReachabilityStatusUnknown,
+ HatenaAFNetworkReachabilityStatusNotReachable,
+ HatenaAFNetworkReachabilityStatusReachableViaWWAN,
+ HatenaAFNetworkReachabilityStatusReachableViaWiFi,
+ }
+
+ `HatenaAFNetworkReachabilityStatusUnknown`
+ The `baseURL` host reachability is not known.
+
+ `HatenaAFNetworkReachabilityStatusNotReachable`
+ The `baseURL` host cannot be reached.
+
+ `HatenaAFNetworkReachabilityStatusReachableViaWWAN`
+ The `baseURL` host can be reached via a cellular connection, such as EDGE or GPRS.
+
+ `HatenaAFNetworkReachabilityStatusReachableViaWiFi`
+ The `baseURL` host can be reached via a Wi-Fi connection.
+
+ ### Keys for Notification UserInfo Dictionary
+
+ Strings that are used as keys in a `userInfo` dictionary in a network reachability status change notification.
+
+ `HatenaAFNetworkingReachabilityNotificationStatusItem`
+ A key in the userInfo dictionary in a `HatenaAFNetworkingReachabilityDidChangeNotification` notification.
+ The corresponding value is an `NSNumber` object representing the `HatenaAFNetworkReachabilityStatus` value for the current reachability status.
+
+ ## Parameter Encoding
+
+ The following constants are provided by `HatenaAFHTTPClient` as possible methods for serializing parameters into query string or message body values.
+
+ enum {
+ HatenaAFFormURLParameterEncoding,
+ HatenaAFJSONParameterEncoding,
+ HatenaAFPropertyListParameterEncoding,
+ }
+
+ `HatenaAFFormURLParameterEncoding`
+ Parameters are encoded into field/key pairs in the URL query string for `GET` `HEAD` and `DELETE` requests, and in the message body otherwise. Dictionary keys are sorted with the `caseInsensitiveCompare:` selector of their description, in order to mitigate the possibility of ambiguous query strings being generated non-deterministically. See the warning for the `parameterEncoding` property for additional information.
+
+ `HatenaAFJSONParameterEncoding`
+ Parameters are encoded into JSON in the message body.
+
+ `HatenaAFPropertyListParameterEncoding`
+ Parameters are encoded into a property list in the message body.
+ */
+
+///----------------
+/// @name Functions
+///----------------
+
+/**
+ Returns a query string constructed by a set of parameters, using the specified encoding.
+
+ Query strings are constructed by collecting each key-value pair, percent escaping a string representation of the key-value pair, and then joining the pairs with "&".
+ 
+ If a query string pair has a an `NSArray` for its value, each member of the array will be represented in the format `field[]=value1&field[]value2`. Otherwise, the pair will be formatted as "field=value". String representations of both keys and values are derived using the `-description` method. The constructed query string does not include the ? character used to delimit the query component.
+ 
+ @param parameters The parameters used to construct the query string
+ @param encoding The encoding to use in constructing the query string. If you are uncertain of the correct encoding, you should use UTF-8 (`NSUTF8StringEncoding`), which is the encoding designated by RFC 3986 as the correct encoding for use in URLs.
+
+ @return A percent-escaped query string
+ */
+extern NSString * HatenaAFQueryStringFromParametersWithEncoding(NSDictionary *parameters, NSStringEncoding encoding);
+
+///--------------------
+/// @name Notifications
+///--------------------
+
+/**
+ Posted when network reachability changes.
+ This notification assigns no notification object. The `userInfo` dictionary contains an `NSNumber` object under the `HatenaAFNetworkingReachabilityNotificationStatusItem` key, representing the `HatenaAFNetworkReachabilityStatus` value for the current network reachability.
+
+ @warning In order for network reachability to be monitored, include the `SystemConfiguration` framework in the active target's "Link Binary With Library" build phase, and add `#import <SystemConfiguration/SystemConfiguration.h>` to the header prefix of the project (`Prefix.pch`).
+ */
+#ifdef _SYSTEMCONFIGURATION_H
+extern NSString * const HatenaAFNetworkingReachabilityDidChangeNotification;
+extern NSString * const HatenaAFNetworkingReachabilityNotificationStatusItem;
+#endif
+
+#pragma mark -
+
+extern NSUInteger const kHatenaAFUploadStream3GSuggestedPacketSize;
+extern NSTimeInterval const kHatenaAFUploadStream3GSuggestedDelay;
+
+/**
+ The `HatenaAFMultipartFormData` protocol defines the methods supported by the parameter in the block argument of `HatenaAFHTTPClient -multipartFormRequestWithMethod:path:parameters:constructingBodyWithBlock:`.
+ */
+@protocol HatenaAFMultipartFormData
+
+/**
+ Appends the HTTP header `Content-Disposition: file; filename=#{generated filename}; name=#{name}"` and `Content-Type: #{generated mimeType}`, followed by the encoded file data and the multipart form boundary.
+
+ The filename and MIME type for this data in the form will be automatically generated, using the last path component of the `fileURL` and system associated MIME type for the `fileURL` extension, respectively.
+ 
+ @param fileURL The URL corresponding to the file whose content will be appended to the form. This parameter must not be `nil`.
+ @param name The name to be associated with the specified data. This parameter must not be `nil`.
+ @param error If an error occurs, upon return contains an `NSError` object that describes the problem.
+
+ @return `YES` if the file data was successfully appended, otherwise `NO`.
+ */
+- (BOOL)appendPartWithFileURL:(NSURL *)fileURL
+                         name:(NSString *)name
+                        error:(NSError * __autoreleasing *)error;
+
+/**
+ Appends the HTTP header `Content-Disposition: file; filename=#{filename}; name=#{name}"` and `Content-Type: #{mimeType}`, followed by the encoded file data and the multipart form boundary.
+
+ @param fileURL The URL corresponding to the file whose content will be appended to the form. This parameter must not be `nil`.
+ @param name The name to be associated with the specified data. This parameter must not be `nil`.
+ @param fileName The file name to be used in the `Content-Disposition` header. This parameter must not be `nil`.
+ @param mimeType The declared MIME type of the file data. This parameter must not be `nil`.
+ @param error If an error occurs, upon return contains an `NSError` object that describes the problem.
+
+ @return `YES` if the file data was successfully appended otherwise `NO`.
+ */
+- (BOOL)appendPartWithFileURL:(NSURL *)fileURL
+                         name:(NSString *)name
+                     fileName:(NSString *)fileName
+                     mimeType:(NSString *)mimeType
+                        error:(NSError * __autoreleasing *)error;
+
+/**
+ Appends the HTTP header `Content-Disposition: file; filename=#{filename}; name=#{name}"` and `Content-Type: #{mimeType}`, followed by the data from the input stream and the multipart form boundary.
+
+ @param inputStream The input stream to be appended to the form data
+ @param name The name to be associated with the specified input stream. This parameter must not be `nil`.
+ @param fileName The filename to be associated with the specified input stream. This parameter must not be `nil`.
+ @param length The length of the specified input stream in bytes.
+ @param mimeType The MIME type of the specified data. (For example, the MIME type for a JPEG image is image/jpeg.) For a list of valid MIME types, see http://www.iana.org/assignments/media-types/. This parameter must not be `nil`.
+ */
+- (void)appendPartWithInputStream:(NSInputStream *)inputStream
+                             name:(NSString *)name
+                         fileName:(NSString *)fileName
+                           length:(unsigned long long)length
+                         mimeType:(NSString *)mimeType;
+
+/**
+ Appends the HTTP header `Content-Disposition: file; filename=#{filename}; name=#{name}"` and `Content-Type: #{mimeType}`, followed by the encoded file data and the multipart form boundary.
+
+ @param data The data to be encoded and appended to the form data.
+ @param name The name to be associated with the specified data. This parameter must not be `nil`.
+ @param fileName The filename to be associated with the specified data. This parameter must not be `nil`.
+ @param mimeType The MIME type of the specified data. (For example, the MIME type for a JPEG image is image/jpeg.) For a list of valid MIME types, see http://www.iana.org/assignments/media-types/. This parameter must not be `nil`.
+ */
+- (void)appendPartWithFileData:(NSData *)data
+                          name:(NSString *)name
+                      fileName:(NSString *)fileName
+                      mimeType:(NSString *)mimeType;
+
+/**
+ Appends the HTTP headers `Content-Disposition: form-data; name=#{name}"`, followed by the encoded data and the multipart form boundary.
+
+ @param data The data to be encoded and appended to the form data.
+ @param name The name to be associated with the specified data. This parameter must not be `nil`.
+ */
+
+- (void)appendPartWithFormData:(NSData *)data
+                          name:(NSString *)name;
+
+
+/**
+ Appends HTTP headers, followed by the encoded data and the multipart form boundary.
+
+ @param headers The HTTP headers to be appended to the form data.
+ @param body The data to be encoded and appended to the form data.
+ */
+- (void)appendPartWithHeaders:(NSDictionary *)headers
+                         body:(NSData *)body;
+
+/**
+ Throttles request bandwidth by limiting the packet size and adding a delay for each chunk read from the upload stream.
+
+ When uploading over a 3G or EDGE connection, requests may fail with "request body stream exhausted". Setting a maximum packet size and delay according to the recommended values (`kHatenaAFUploadStream3GSuggestedPacketSize` and `kHatenaAFUploadStream3GSuggestedDelay`) lowers the risk of the input stream exceeding its allocated bandwidth. Unfortunately, as of iOS 6, there is no definite way to distinguish between a 3G, EDGE, or LTE connection. As such, it is not recommended that you throttle bandwidth based solely on network reachability. Instead, you should consider checking for the "request body stream exhausted" in a failure block, and then retrying the request with throttled bandwidth.
+
+ @param numberOfBytes Maximum packet size, in number of bytes. The default packet size for an input stream is 32kb.
+ @param delay Duration of delay each time a packet is read. By default, no delay is set.
+ */
+- (void)throttleBandwidthWithPacketSize:(NSUInteger)numberOfBytes
+                                  delay:(NSTimeInterval)delay;
+
+@end

--- a/SDK/API/AFNetworking/HatenaAFHTTPClient.m
+++ b/SDK/API/AFNetworking/HatenaAFHTTPClient.m
@@ -1,0 +1,1395 @@
+// HatenaAFHTTPClient.m
+//
+// Copyright (c) 2011 Gowalla (http://gowalla.com/)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <Foundation/Foundation.h>
+
+#import "HatenaAFHTTPClient.h"
+#import "HatenaAFHTTPRequestOperation.h"
+
+#import <Availability.h>
+
+#ifdef _SYSTEMCONFIGURATION_H
+#import <netinet/in.h>
+#import <netinet6/in6.h>
+#import <arpa/inet.h>
+#import <ifaddrs.h>
+#import <netdb.h>
+#endif
+
+#if defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
+#import <UIKit/UIKit.h>
+#endif
+
+#ifdef _SYSTEMCONFIGURATION_H
+NSString * const HatenaAFNetworkingReachabilityDidChangeNotification = @"com.alamofire.networking.reachability.change";
+NSString * const HatenaAFNetworkingReachabilityNotificationStatusItem = @"HatenaAFNetworkingReachabilityNotificationStatusItem";
+
+typedef SCNetworkReachabilityRef HatenaAFNetworkReachabilityRef;
+typedef void (^HatenaAFNetworkReachabilityStatusBlock)(HatenaAFNetworkReachabilityStatus status);
+#else
+typedef id HatenaAFNetworkReachabilityRef;
+#endif
+
+typedef void (^HatenaAFCompletionBlock)(void);
+
+static NSString * HatenaAFBase64EncodedStringFromString(NSString *string) {
+    NSData *data = [NSData dataWithBytes:[string UTF8String] length:[string lengthOfBytesUsingEncoding:NSUTF8StringEncoding]];
+    NSUInteger length = [data length];
+    NSMutableData *mutableData = [NSMutableData dataWithLength:((length + 2) / 3) * 4];
+
+    uint8_t *input = (uint8_t *)[data bytes];
+    uint8_t *output = (uint8_t *)[mutableData mutableBytes];
+
+    for (NSUInteger i = 0; i < length; i += 3) {
+        NSUInteger value = 0;
+        for (NSUInteger j = i; j < (i + 3); j++) {
+            value <<= 8;
+            if (j < length) {
+                value |= (0xFF & input[j]);
+            }
+        }
+
+        static uint8_t const kHatenaAFBase64EncodingTable[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+        NSUInteger idx = (i / 3) * 4;
+        output[idx + 0] = kHatenaAFBase64EncodingTable[(value >> 18) & 0x3F];
+        output[idx + 1] = kHatenaAFBase64EncodingTable[(value >> 12) & 0x3F];
+        output[idx + 2] = (i + 1) < length ? kHatenaAFBase64EncodingTable[(value >> 6)  & 0x3F] : '=';
+        output[idx + 3] = (i + 2) < length ? kHatenaAFBase64EncodingTable[(value >> 0)  & 0x3F] : '=';
+    }
+
+    return [[NSString alloc] initWithData:mutableData encoding:NSASCIIStringEncoding];
+}
+
+static NSString * const kHatenaAFCharactersToBeEscapedInQueryString = @":/?&=;+!@#$()',*";
+
+static NSString * HatenaAFPercentEscapedQueryStringKeyFromStringWithEncoding(NSString *string, NSStringEncoding encoding) {
+    static NSString * const kHatenaAFCharactersToLeaveUnescapedInQueryStringPairKey = @"[].";
+
+	return (__bridge_transfer  NSString *)CFURLCreateStringByAddingPercentEscapes(kCFAllocatorDefault, (__bridge CFStringRef)string, (__bridge CFStringRef)kHatenaAFCharactersToLeaveUnescapedInQueryStringPairKey, (__bridge CFStringRef)kHatenaAFCharactersToBeEscapedInQueryString, CFStringConvertNSStringEncodingToEncoding(encoding));
+}
+
+static NSString * HatenaAFPercentEscapedQueryStringValueFromStringWithEncoding(NSString *string, NSStringEncoding encoding) {
+	return (__bridge_transfer  NSString *)CFURLCreateStringByAddingPercentEscapes(kCFAllocatorDefault, (__bridge CFStringRef)string, NULL, (__bridge CFStringRef)kHatenaAFCharactersToBeEscapedInQueryString, CFStringConvertNSStringEncodingToEncoding(encoding));
+}
+
+#pragma mark -
+
+@interface HatenaAFQueryStringPair : NSObject
+@property (readwrite, nonatomic, strong) id field;
+@property (readwrite, nonatomic, strong) id value;
+
+- (id)initWithField:(id)field value:(id)value;
+
+- (NSString *)URLEncodedStringValueWithEncoding:(NSStringEncoding)stringEncoding;
+@end
+
+@implementation HatenaAFQueryStringPair
+@synthesize field = _field;
+@synthesize value = _value;
+
+- (id)initWithField:(id)field value:(id)value {
+    self = [super init];
+    if (!self) {
+        return nil;
+    }
+
+    self.field = field;
+    self.value = value;
+
+    return self;
+}
+
+- (NSString *)URLEncodedStringValueWithEncoding:(NSStringEncoding)stringEncoding {
+    if (!self.value || [self.value isEqual:[NSNull null]]) {
+        return HatenaAFPercentEscapedQueryStringKeyFromStringWithEncoding([self.field description], stringEncoding);
+    } else {
+        return [NSString stringWithFormat:@"%@=%@", HatenaAFPercentEscapedQueryStringKeyFromStringWithEncoding([self.field description], stringEncoding), HatenaAFPercentEscapedQueryStringValueFromStringWithEncoding([self.value description], stringEncoding)];
+    }
+}
+
+@end
+
+#pragma mark -
+
+extern NSArray * HatenaAFQueryStringPairsFromDictionary(NSDictionary *dictionary);
+extern NSArray * HatenaAFQueryStringPairsFromKeyAndValue(NSString *key, id value);
+
+NSString * HatenaAFQueryStringFromParametersWithEncoding(NSDictionary *parameters, NSStringEncoding stringEncoding) {
+    NSMutableArray *mutablePairs = [NSMutableArray array];
+    for (HatenaAFQueryStringPair *pair in HatenaAFQueryStringPairsFromDictionary(parameters)) {
+        [mutablePairs addObject:[pair URLEncodedStringValueWithEncoding:stringEncoding]];
+    }
+
+    return [mutablePairs componentsJoinedByString:@"&"];
+}
+
+NSArray * HatenaAFQueryStringPairsFromDictionary(NSDictionary *dictionary) {
+    return HatenaAFQueryStringPairsFromKeyAndValue(nil, dictionary);
+}
+
+NSArray * HatenaAFQueryStringPairsFromKeyAndValue(NSString *key, id value) {
+    NSMutableArray *mutableQueryStringComponents = [NSMutableArray array];
+
+    if ([value isKindOfClass:[NSDictionary class]]) {
+        NSDictionary *dictionary = value;
+        // Sort dictionary keys to ensure consistent ordering in query string, which is important when deserializing potentially ambiguous sequences, such as an array of dictionaries
+        NSSortDescriptor *sortDescriptor = [NSSortDescriptor sortDescriptorWithKey:@"description" ascending:YES selector:@selector(caseInsensitiveCompare:)];
+        for (id nestedKey in [dictionary.allKeys sortedArrayUsingDescriptors:@[ sortDescriptor ]]) {
+            id nestedValue = [dictionary objectForKey:nestedKey];
+            if (nestedValue) {
+                [mutableQueryStringComponents addObjectsFromArray:HatenaAFQueryStringPairsFromKeyAndValue((key ? [NSString stringWithFormat:@"%@[%@]", key, nestedKey] : nestedKey), nestedValue)];
+            }
+        }
+    } else if ([value isKindOfClass:[NSArray class]]) {
+        NSArray *array = value;
+        for (id nestedValue in array) {
+            [mutableQueryStringComponents addObjectsFromArray:HatenaAFQueryStringPairsFromKeyAndValue([NSString stringWithFormat:@"%@[]", key], nestedValue)];
+        }
+    } else if ([value isKindOfClass:[NSSet class]]) {
+        NSSet *set = value;
+        for (id obj in set) {
+            [mutableQueryStringComponents addObjectsFromArray:HatenaAFQueryStringPairsFromKeyAndValue(key, obj)];
+        }
+    } else {
+        [mutableQueryStringComponents addObject:[[HatenaAFQueryStringPair alloc] initWithField:key value:value]];
+    }
+
+    return mutableQueryStringComponents;
+}
+
+@interface HatenaAFStreamingMultipartFormData : NSObject <HatenaAFMultipartFormData>
+- (id)initWithURLRequest:(NSMutableURLRequest *)urlRequest
+          stringEncoding:(NSStringEncoding)encoding;
+
+- (NSMutableURLRequest *)requestByFinalizingMultipartFormData;
+@end
+
+#pragma mark -
+
+@interface HatenaAFHTTPClient ()
+@property (readwrite, nonatomic, strong) NSURL *baseURL;
+@property (readwrite, nonatomic, strong) NSMutableArray *registeredHTTPOperationClassNames;
+@property (readwrite, nonatomic, strong) NSMutableDictionary *defaultHeaders;
+@property (readwrite, nonatomic, strong) NSURLCredential *defaultCredential;
+@property (readwrite, nonatomic, strong) NSOperationQueue *operationQueue;
+#ifdef _SYSTEMCONFIGURATION_H
+@property (readwrite, nonatomic, assign) HatenaAFNetworkReachabilityRef networkReachability;
+@property (readwrite, nonatomic, assign) HatenaAFNetworkReachabilityStatus networkReachabilityStatus;
+@property (readwrite, nonatomic, copy) HatenaAFNetworkReachabilityStatusBlock networkReachabilityStatusBlock;
+#endif
+
+#ifdef _SYSTEMCONFIGURATION_H
+- (void)startMonitoringNetworkReachability;
+- (void)stopMonitoringNetworkReachability;
+#endif
+@end
+
+@implementation HatenaAFHTTPClient
+@synthesize baseURL = _baseURL;
+@synthesize stringEncoding = _stringEncoding;
+@synthesize parameterEncoding = _parameterEncoding;
+@synthesize registeredHTTPOperationClassNames = _registeredHTTPOperationClassNames;
+@synthesize defaultHeaders = _defaultHeaders;
+@synthesize defaultCredential = _defaultCredential;
+@synthesize operationQueue = _operationQueue;
+#ifdef _SYSTEMCONFIGURATION_H
+@synthesize networkReachability = _networkReachability;
+@synthesize networkReachabilityStatus = _networkReachabilityStatus;
+@synthesize networkReachabilityStatusBlock = _networkReachabilityStatusBlock;
+#endif
+@synthesize defaultSSLPinningMode = _defaultSSLPinningMode;
+@synthesize allowsInvalidSSLCertificate = _allowsInvalidSSLCertificate;
+
++ (instancetype)clientWithBaseURL:(NSURL *)url {
+    return [[self alloc] initWithBaseURL:url];
+}
+
+- (id)init {
+    @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:[NSString stringWithFormat:@"%@ Failed to call designated initializer. Invoke `initWithBaseURL:` instead.", NSStringFromClass([self class])] userInfo:nil];
+}
+
+- (id)initWithBaseURL:(NSURL *)url {
+    NSParameterAssert(url);
+
+    self = [super init];
+    if (!self) {
+        return nil;
+    }
+
+    // Ensure terminal slash for baseURL path, so that NSURL +URLWithString:relativeToURL: works as expected
+    if ([[url path] length] > 0 && ![[url absoluteString] hasSuffix:@"/"]) {
+        url = [url URLByAppendingPathComponent:@""];
+    }
+
+    self.baseURL = url;
+
+    self.stringEncoding = NSUTF8StringEncoding;
+    self.parameterEncoding = HatenaAFFormURLParameterEncoding;
+
+    self.registeredHTTPOperationClassNames = [NSMutableArray array];
+
+	self.defaultHeaders = [NSMutableDictionary dictionary];
+
+    // Accept-Language HTTP Header; see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.4
+    NSMutableArray *acceptLanguagesComponents = [NSMutableArray array];
+    [[NSLocale preferredLanguages] enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
+        float q = 1.0f - (idx * 0.1f);
+        [acceptLanguagesComponents addObject:[NSString stringWithFormat:@"%@;q=%0.1g", obj, q]];
+        *stop = q <= 0.5f;
+    }];
+    [self setDefaultHeader:@"Accept-Language" value:[acceptLanguagesComponents componentsJoinedByString:@", "]];
+
+    NSString *userAgent = nil;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wgnu"
+#if defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
+    // User-Agent Header; see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.43
+    userAgent = [NSString stringWithFormat:@"%@/%@ (%@; iOS %@; Scale/%0.2f)", [[[NSBundle mainBundle] infoDictionary] objectForKey:(__bridge NSString *)kCFBundleExecutableKey] ?: [[[NSBundle mainBundle] infoDictionary] objectForKey:(__bridge NSString *)kCFBundleIdentifierKey], (__bridge id)CFBundleGetValueForInfoDictionaryKey(CFBundleGetMainBundle(), kCFBundleVersionKey) ?: [[[NSBundle mainBundle] infoDictionary] objectForKey:(__bridge NSString *)kCFBundleVersionKey], [[UIDevice currentDevice] model], [[UIDevice currentDevice] systemVersion], ([[UIScreen mainScreen] respondsToSelector:@selector(scale)] ? [[UIScreen mainScreen] scale] : 1.0f)];
+#elif defined(__MAC_OS_X_VERSION_MIN_REQUIRED)
+    userAgent = [NSString stringWithFormat:@"%@/%@ (Mac OS X %@)", [[[NSBundle mainBundle] infoDictionary] objectForKey:(__bridge NSString *)kCFBundleExecutableKey] ?: [[[NSBundle mainBundle] infoDictionary] objectForKey:(__bridge NSString *)kCFBundleIdentifierKey], [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleShortVersionString"] ?: [[[NSBundle mainBundle] infoDictionary] objectForKey:(__bridge NSString *)kCFBundleVersionKey], [[NSProcessInfo processInfo] operatingSystemVersionString]];
+#endif
+#pragma clang diagnostic pop
+    if (userAgent) {
+        if (![userAgent canBeConvertedToEncoding:NSASCIIStringEncoding]) {
+            NSMutableString *mutableUserAgent = [userAgent mutableCopy];
+            if (CFStringTransform((__bridge CFMutableStringRef)(mutableUserAgent), NULL, kCFStringTransformToLatin, false)) {
+                userAgent = mutableUserAgent;
+            }
+        }
+        [self setDefaultHeader:@"User-Agent" value:userAgent];
+    }
+
+#ifdef _SYSTEMCONFIGURATION_H
+    self.networkReachabilityStatus = HatenaAFNetworkReachabilityStatusUnknown;
+    [self startMonitoringNetworkReachability];
+#endif
+
+    self.operationQueue = [[NSOperationQueue alloc] init];
+	[self.operationQueue setMaxConcurrentOperationCount:NSOperationQueueDefaultMaxConcurrentOperationCount];
+
+    // #ifdef included for backwards-compatibility
+#ifdef _HatenaAFNETWORKING_ALLOW_INVALID_SSL_CERTIFICATES_
+    self.allowsInvalidSSLCertificate = YES;
+#endif
+    
+    return self;
+}
+
+- (void)dealloc {
+#ifdef _SYSTEMCONFIGURATION_H
+    [self stopMonitoringNetworkReachability];
+#endif
+}
+
+- (NSString *)description {
+    return [NSString stringWithFormat:@"<%@: %p, baseURL: %@, defaultHeaders: %@, registeredOperationClasses: %@, operationQueue: %@>", NSStringFromClass([self class]), self, [self.baseURL absoluteString], self.defaultHeaders, self.registeredHTTPOperationClassNames, self.operationQueue];
+}
+
+#pragma mark -
+
+#ifdef _SYSTEMCONFIGURATION_H
+static BOOL HatenaAFURLHostIsIPAddress(NSURL *url) {
+    struct sockaddr_in sa_in;
+    struct sockaddr_in6 sa_in6;
+
+    return [url host] && (inet_pton(AF_INET, [[url host] UTF8String], &sa_in) == 1 || inet_pton(AF_INET6, [[url host] UTF8String], &sa_in6) == 1);
+}
+
+static HatenaAFNetworkReachabilityStatus HatenaAFNetworkReachabilityStatusForFlags(SCNetworkReachabilityFlags flags) {
+    BOOL isReachable = ((flags & kSCNetworkReachabilityFlagsReachable) != 0);
+    BOOL needsConnection = ((flags & kSCNetworkReachabilityFlagsConnectionRequired) != 0);
+    BOOL canConnectionAutomatically = (((flags & kSCNetworkReachabilityFlagsConnectionOnDemand ) != 0) || ((flags & kSCNetworkReachabilityFlagsConnectionOnTraffic) != 0));
+    BOOL canConnectWithoutUserInteraction = (canConnectionAutomatically && (flags & kSCNetworkReachabilityFlagsInterventionRequired) == 0);
+    BOOL isNetworkReachable = (isReachable && (!needsConnection || canConnectWithoutUserInteraction));
+
+    HatenaAFNetworkReachabilityStatus status = HatenaAFNetworkReachabilityStatusUnknown;
+    if (isNetworkReachable == NO) {
+        status = HatenaAFNetworkReachabilityStatusNotReachable;
+    }
+#if	TARGET_OS_IPHONE
+    else if ((flags & kSCNetworkReachabilityFlagsIsWWAN) != 0) {
+        status = HatenaAFNetworkReachabilityStatusReachableViaWWAN;
+    }
+#endif
+    else {
+        status = HatenaAFNetworkReachabilityStatusReachableViaWiFi;
+    }
+
+    return status;
+}
+
+static void HatenaAFNetworkReachabilityCallback(SCNetworkReachabilityRef __unused target, SCNetworkReachabilityFlags flags, void *info) {
+    HatenaAFNetworkReachabilityStatus status = HatenaAFNetworkReachabilityStatusForFlags(flags);
+    HatenaAFNetworkReachabilityStatusBlock block = (__bridge HatenaAFNetworkReachabilityStatusBlock)info;
+    if (block) {
+        block(status);
+    }
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+        NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
+        [notificationCenter postNotificationName:HatenaAFNetworkingReachabilityDidChangeNotification object:nil userInfo:[NSDictionary dictionaryWithObject:[NSNumber numberWithInteger:status] forKey:HatenaAFNetworkingReachabilityNotificationStatusItem]];
+    });
+}
+
+static const void * HatenaAFNetworkReachabilityRetainCallback(const void *info) {
+    return Block_copy(info);
+}
+
+static void HatenaAFNetworkReachabilityReleaseCallback(const void *info) {
+    if (info) {
+        Block_release(info);
+    }
+}
+
+- (void)startMonitoringNetworkReachability {
+    [self stopMonitoringNetworkReachability];
+
+    if (!self.baseURL) {
+        return;
+    }
+
+    self.networkReachability = SCNetworkReachabilityCreateWithName(kCFAllocatorDefault, [[self.baseURL host] UTF8String]);
+
+    if (!self.networkReachability) {
+        return;
+    }
+
+    __weak __typeof(&*self)weakSelf = self;
+    HatenaAFNetworkReachabilityStatusBlock callback = ^(HatenaAFNetworkReachabilityStatus status) {
+        __strong __typeof(&*weakSelf)strongSelf = weakSelf;
+        if (!strongSelf) {
+            return;
+        }
+
+        strongSelf.networkReachabilityStatus = status;
+        if (strongSelf.networkReachabilityStatusBlock) {
+            strongSelf.networkReachabilityStatusBlock(status);
+        }
+    };
+
+    SCNetworkReachabilityContext context = {0, (__bridge void *)callback, HatenaAFNetworkReachabilityRetainCallback, HatenaAFNetworkReachabilityReleaseCallback, NULL};
+    SCNetworkReachabilitySetCallback(self.networkReachability, HatenaAFNetworkReachabilityCallback, &context);
+
+    /* Network reachability monitoring does not establish a baseline for IP addresses as it does for hostnames, so if the base URL host is an IP address, the initial reachability callback is manually triggered.
+     */
+    if (HatenaAFURLHostIsIPAddress(self.baseURL)) {
+        SCNetworkReachabilityFlags flags;
+        SCNetworkReachabilityGetFlags(self.networkReachability, &flags);
+        dispatch_async(dispatch_get_main_queue(), ^{
+            HatenaAFNetworkReachabilityStatus status = HatenaAFNetworkReachabilityStatusForFlags(flags);
+            callback(status);
+        });
+    }
+
+    SCNetworkReachabilityScheduleWithRunLoop(self.networkReachability, CFRunLoopGetMain(), kCFRunLoopCommonModes);
+}
+
+- (void)stopMonitoringNetworkReachability {
+    if (self.networkReachability) {
+        SCNetworkReachabilityUnscheduleFromRunLoop(self.networkReachability, CFRunLoopGetMain(), kCFRunLoopCommonModes);
+
+        CFRelease(_networkReachability);
+        _networkReachability = NULL;
+    }
+}
+
+- (void)setReachabilityStatusChangeBlock:(void (^)(HatenaAFNetworkReachabilityStatus status))block {
+    self.networkReachabilityStatusBlock = block;
+}
+#endif
+
+#pragma mark -
+
+- (BOOL)registerHTTPOperationClass:(Class)operationClass {
+    if (![operationClass isSubclassOfClass:[HatenaAFHTTPRequestOperation class]]) {
+        return NO;
+    }
+
+    NSString *className = NSStringFromClass(operationClass);
+    [self.registeredHTTPOperationClassNames removeObject:className];
+    [self.registeredHTTPOperationClassNames insertObject:className atIndex:0];
+
+    return YES;
+}
+
+- (void)unregisterHTTPOperationClass:(Class)operationClass {
+    NSString *className = NSStringFromClass(operationClass);
+    [self.registeredHTTPOperationClassNames removeObject:className];
+}
+
+#pragma mark -
+
+- (NSString *)defaultValueForHeader:(NSString *)header {
+	return [self.defaultHeaders valueForKey:header];
+}
+
+- (void)setDefaultHeader:(NSString *)header value:(NSString *)value {
+	[self.defaultHeaders setValue:value forKey:header];
+}
+
+- (void)setAuthorizationHeaderWithUsername:(NSString *)username password:(NSString *)password {
+	NSString *basicAuthCredentials = [NSString stringWithFormat:@"%@:%@", username, password];
+    [self setDefaultHeader:@"Authorization" value:[NSString stringWithFormat:@"Basic %@", HatenaAFBase64EncodedStringFromString(basicAuthCredentials)]];
+}
+
+- (void)setAuthorizationHeaderWithToken:(NSString *)token {
+    [self setDefaultHeader:@"Authorization" value:[NSString stringWithFormat:@"Token token=\"%@\"", token]];
+}
+
+- (void)clearAuthorizationHeader {
+	[self.defaultHeaders removeObjectForKey:@"Authorization"];
+}
+
+#pragma mark -
+
+- (NSMutableURLRequest *)requestWithMethod:(NSString *)method
+                                      path:(NSString *)path
+                                parameters:(NSDictionary *)parameters
+{
+    NSParameterAssert(method);
+
+    if (!path) {
+        path = @"";
+    }
+
+    NSURL *url = [NSURL URLWithString:path relativeToURL:self.baseURL];
+	NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:url];
+    [request setHTTPMethod:method];
+    [request setAllHTTPHeaderFields:self.defaultHeaders];
+
+    if (parameters) {
+        if ([method isEqualToString:@"GET"] || [method isEqualToString:@"HEAD"] || [method isEqualToString:@"DELETE"]) {
+            url = [NSURL URLWithString:[[url absoluteString] stringByAppendingFormat:[path rangeOfString:@"?"].location == NSNotFound ? @"?%@" : @"&%@", HatenaAFQueryStringFromParametersWithEncoding(parameters, self.stringEncoding)]];
+            [request setURL:url];
+        } else {
+            NSString *charset = (__bridge NSString *)CFStringConvertEncodingToIANACharSetName(CFStringConvertNSStringEncodingToEncoding(self.stringEncoding));
+            NSError *error = nil;
+
+            switch (self.parameterEncoding) {
+                case HatenaAFFormURLParameterEncoding:;
+                    [request setValue:[NSString stringWithFormat:@"application/x-www-form-urlencoded; charset=%@", charset] forHTTPHeaderField:@"Content-Type"];
+                    [request setHTTPBody:[HatenaAFQueryStringFromParametersWithEncoding(parameters, self.stringEncoding) dataUsingEncoding:self.stringEncoding]];
+                    break;
+                case HatenaAFJSONParameterEncoding:;
+                    [request setValue:[NSString stringWithFormat:@"application/json; charset=%@", charset] forHTTPHeaderField:@"Content-Type"];
+                    [request setHTTPBody:[NSJSONSerialization dataWithJSONObject:parameters options:(NSJSONWritingOptions)0 error:&error]];
+                    break;
+                case HatenaAFPropertyListParameterEncoding:;
+                    [request setValue:[NSString stringWithFormat:@"application/x-plist; charset=%@", charset] forHTTPHeaderField:@"Content-Type"];
+                    [request setHTTPBody:[NSPropertyListSerialization dataWithPropertyList:parameters format:NSPropertyListXMLFormat_v1_0 options:0 error:&error]];
+                    break;
+            }
+
+            if (error) {
+                NSLog(@"%@ %@: %@", [self class], NSStringFromSelector(_cmd), error);
+            }
+        }
+    }
+
+	return request;
+}
+
+- (NSMutableURLRequest *)multipartFormRequestWithMethod:(NSString *)method
+                                                   path:(NSString *)path
+                                             parameters:(NSDictionary *)parameters
+                              constructingBodyWithBlock:(void (^)(id <HatenaAFMultipartFormData> formData))block
+{
+    NSParameterAssert(method);
+    NSParameterAssert(![method isEqualToString:@"GET"] && ![method isEqualToString:@"HEAD"]);
+
+    NSMutableURLRequest *request = [self requestWithMethod:method path:path parameters:nil];
+
+    __block HatenaAFStreamingMultipartFormData *formData = [[HatenaAFStreamingMultipartFormData alloc] initWithURLRequest:request stringEncoding:self.stringEncoding];
+
+    if (parameters) {
+        for (HatenaAFQueryStringPair *pair in HatenaAFQueryStringPairsFromDictionary(parameters)) {
+            NSData *data = nil;
+            if ([pair.value isKindOfClass:[NSData class]]) {
+                data = pair.value;
+            } else if ([pair.value isEqual:[NSNull null]]) {
+                data = [NSData data];
+            } else {
+                data = [[pair.value description] dataUsingEncoding:self.stringEncoding];
+            }
+
+            if (data) {
+                [formData appendPartWithFormData:data name:[pair.field description]];
+            }
+        }
+    }
+
+    if (block) {
+        block(formData);
+    }
+
+    return [formData requestByFinalizingMultipartFormData];
+}
+
+- (HatenaAFHTTPRequestOperation *)HTTPRequestOperationWithRequest:(NSURLRequest *)urlRequest
+                                                    success:(void (^)(HatenaAFHTTPRequestOperation *operation, id responseObject))success
+                                                    failure:(void (^)(HatenaAFHTTPRequestOperation *operation, NSError *error))failure
+{
+    HatenaAFHTTPRequestOperation *operation = nil;
+    
+    for (NSString *className in self.registeredHTTPOperationClassNames) {
+        Class operationClass = NSClassFromString(className);
+        if (operationClass && [operationClass canProcessRequest:urlRequest]) {
+            operation = [(HatenaAFHTTPRequestOperation *)[operationClass alloc] initWithRequest:urlRequest];
+            break;
+        }
+    }
+
+    if (!operation) {
+        operation = [[HatenaAFHTTPRequestOperation alloc] initWithRequest:urlRequest];
+    }
+
+    [operation setCompletionBlockWithSuccess:success failure:failure];
+
+    operation.credential = self.defaultCredential;
+    operation.SSLPinningMode = self.defaultSSLPinningMode;
+    operation.allowsInvalidSSLCertificate = self.allowsInvalidSSLCertificate;
+
+    return operation;
+}
+
+#pragma mark -
+
+- (void)enqueueHTTPRequestOperation:(HatenaAFHTTPRequestOperation *)operation {
+    [self.operationQueue addOperation:operation];
+}
+
+- (void)cancelAllHTTPOperationsWithMethod:(NSString *)method
+                                     path:(NSString *)path
+{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wgnu"
+    NSString *pathToBeMatched = [[[self requestWithMethod:(method ?: @"GET") path:path parameters:nil] URL] path];
+#pragma clang diagnostic pop
+
+    for (NSOperation *operation in [self.operationQueue operations]) {
+        if (![operation isKindOfClass:[HatenaAFHTTPRequestOperation class]]) {
+            continue;
+        }
+
+        BOOL hasMatchingMethod = !method || [method isEqualToString:[[(HatenaAFHTTPRequestOperation *)operation request] HTTPMethod]];
+        BOOL hasMatchingPath = [[[[(HatenaAFHTTPRequestOperation *)operation request] URL] path] isEqual:pathToBeMatched];
+
+        if (hasMatchingMethod && hasMatchingPath) {
+            [operation cancel];
+        }
+    }
+}
+
+- (void)enqueueBatchOfHTTPRequestOperationsWithRequests:(NSArray *)urlRequests
+                                          progressBlock:(void (^)(NSUInteger numberOfFinishedOperations, NSUInteger totalNumberOfOperations))progressBlock
+                                        completionBlock:(void (^)(NSArray *operations))completionBlock
+{
+    NSMutableArray *mutableOperations = [NSMutableArray array];
+    for (NSURLRequest *request in urlRequests) {
+        HatenaAFHTTPRequestOperation *operation = [self HTTPRequestOperationWithRequest:request success:nil failure:nil];
+        [mutableOperations addObject:operation];
+    }
+
+    [self enqueueBatchOfHTTPRequestOperations:mutableOperations progressBlock:progressBlock completionBlock:completionBlock];
+}
+
+- (void)enqueueBatchOfHTTPRequestOperations:(NSArray *)operations
+                              progressBlock:(void (^)(NSUInteger numberOfFinishedOperations, NSUInteger totalNumberOfOperations))progressBlock
+                            completionBlock:(void (^)(NSArray *operations))completionBlock
+{
+    __block dispatch_group_t dispatchGroup = dispatch_group_create();
+    NSBlockOperation *batchedOperation = [NSBlockOperation blockOperationWithBlock:^{
+        dispatch_group_notify(dispatchGroup, dispatch_get_main_queue(), ^{
+            if (completionBlock) {
+                completionBlock(operations);
+            }
+        });
+#if !OS_OBJECT_USE_OBJC
+        dispatch_release(dispatchGroup);
+#endif
+    }];
+
+    for (HatenaAFHTTPRequestOperation *operation in operations) {
+        HatenaAFCompletionBlock originalCompletionBlock = [operation.completionBlock copy];
+        __weak __typeof(&*operation)weakOperation = operation;
+        operation.completionBlock = ^{
+            __strong __typeof(&*weakOperation)strongOperation = weakOperation;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wgnu"
+            dispatch_queue_t queue = strongOperation.successCallbackQueue ?: dispatch_get_main_queue();
+#pragma clang diagnostic pop
+            dispatch_group_async(dispatchGroup, queue, ^{
+                if (originalCompletionBlock) {
+                    originalCompletionBlock();
+                }
+
+                NSUInteger numberOfFinishedOperations = [[operations indexesOfObjectsPassingTest:^BOOL(id op, NSUInteger __unused idx,  BOOL __unused *stop) {
+                    return [op isFinished];
+                }] count];
+
+                if (progressBlock) {
+                    progressBlock(numberOfFinishedOperations, [operations count]);
+                }
+
+                dispatch_group_leave(dispatchGroup);
+            });
+        };
+
+        dispatch_group_enter(dispatchGroup);
+        [batchedOperation addDependency:operation];
+    }
+    [self.operationQueue addOperations:operations waitUntilFinished:NO];
+    [self.operationQueue addOperation:batchedOperation];
+}
+
+#pragma mark -
+
+- (void)getPath:(NSString *)path
+     parameters:(NSDictionary *)parameters
+        success:(void (^)(HatenaAFHTTPRequestOperation *operation, id responseObject))success
+        failure:(void (^)(HatenaAFHTTPRequestOperation *operation, NSError *error))failure
+{
+	NSURLRequest *request = [self requestWithMethod:@"GET" path:path parameters:parameters];
+    HatenaAFHTTPRequestOperation *operation = [self HTTPRequestOperationWithRequest:request success:success failure:failure];
+    [self enqueueHTTPRequestOperation:operation];
+}
+
+- (void)postPath:(NSString *)path
+      parameters:(NSDictionary *)parameters
+         success:(void (^)(HatenaAFHTTPRequestOperation *operation, id responseObject))success
+         failure:(void (^)(HatenaAFHTTPRequestOperation *operation, NSError *error))failure
+{
+	NSURLRequest *request = [self requestWithMethod:@"POST" path:path parameters:parameters];
+	HatenaAFHTTPRequestOperation *operation = [self HTTPRequestOperationWithRequest:request success:success failure:failure];
+    [self enqueueHTTPRequestOperation:operation];
+}
+
+- (void)putPath:(NSString *)path
+     parameters:(NSDictionary *)parameters
+        success:(void (^)(HatenaAFHTTPRequestOperation *operation, id responseObject))success
+        failure:(void (^)(HatenaAFHTTPRequestOperation *operation, NSError *error))failure
+{
+	NSURLRequest *request = [self requestWithMethod:@"PUT" path:path parameters:parameters];
+	HatenaAFHTTPRequestOperation *operation = [self HTTPRequestOperationWithRequest:request success:success failure:failure];
+    [self enqueueHTTPRequestOperation:operation];
+}
+
+- (void)deletePath:(NSString *)path
+        parameters:(NSDictionary *)parameters
+           success:(void (^)(HatenaAFHTTPRequestOperation *operation, id responseObject))success
+           failure:(void (^)(HatenaAFHTTPRequestOperation *operation, NSError *error))failure
+{
+	NSURLRequest *request = [self requestWithMethod:@"DELETE" path:path parameters:parameters];
+	HatenaAFHTTPRequestOperation *operation = [self HTTPRequestOperationWithRequest:request success:success failure:failure];
+    [self enqueueHTTPRequestOperation:operation];
+}
+
+- (void)patchPath:(NSString *)path
+       parameters:(NSDictionary *)parameters
+          success:(void (^)(HatenaAFHTTPRequestOperation *operation, id responseObject))success
+          failure:(void (^)(HatenaAFHTTPRequestOperation *operation, NSError *error))failure
+{
+    NSURLRequest *request = [self requestWithMethod:@"PATCH" path:path parameters:parameters];
+	HatenaAFHTTPRequestOperation *operation = [self HTTPRequestOperationWithRequest:request success:success failure:failure];
+    [self enqueueHTTPRequestOperation:operation];
+}
+
+#pragma mark - NSCoding
+
+- (id)initWithCoder:(NSCoder *)aDecoder {
+    NSURL *baseURL = [aDecoder decodeObjectForKey:@"baseURL"];
+
+    self = [self initWithBaseURL:baseURL];
+    if (!self) {
+        return nil;
+    }
+
+    self.stringEncoding = [aDecoder decodeIntegerForKey:@"stringEncoding"];
+    self.parameterEncoding = (HatenaAFHTTPClientParameterEncoding) [aDecoder decodeIntegerForKey:@"parameterEncoding"];
+    self.registeredHTTPOperationClassNames = [aDecoder decodeObjectForKey:@"registeredHTTPOperationClassNames"];
+    self.defaultHeaders = [aDecoder decodeObjectForKey:@"defaultHeaders"];
+
+    return self;
+}
+
+- (void)encodeWithCoder:(NSCoder *)aCoder {
+    [aCoder encodeObject:self.baseURL forKey:@"baseURL"];
+    [aCoder encodeInteger:(NSInteger)self.stringEncoding forKey:@"stringEncoding"];
+    [aCoder encodeInteger:self.parameterEncoding forKey:@"parameterEncoding"];
+    [aCoder encodeObject:self.registeredHTTPOperationClassNames forKey:@"registeredHTTPOperationClassNames"];
+    [aCoder encodeObject:self.defaultHeaders forKey:@"defaultHeaders"];
+}
+
+#pragma mark - NSCopying
+
+- (id)copyWithZone:(NSZone *)zone {
+    HatenaAFHTTPClient *HTTPClient = [[[self class] allocWithZone:zone] initWithBaseURL:self.baseURL];
+
+    HTTPClient.stringEncoding = self.stringEncoding;
+    HTTPClient.parameterEncoding = self.parameterEncoding;
+    HTTPClient.registeredHTTPOperationClassNames = [self.registeredHTTPOperationClassNames mutableCopyWithZone:zone];
+    HTTPClient.defaultHeaders = [self.defaultHeaders mutableCopyWithZone:zone];
+#ifdef _SYSTEMCONFIGURATION_H
+    HTTPClient.networkReachabilityStatusBlock = self.networkReachabilityStatusBlock;
+#endif
+    return HTTPClient;
+}
+
+@end
+
+#pragma mark -
+
+static NSString * const kHatenaAFMultipartFormBoundary = @"Boundary+0xAbCdEfGbOuNdArY";
+
+static NSString * const kHatenaAFMultipartFormCRLF = @"\r\n";
+
+static inline NSString * HatenaAFMultipartFormInitialBoundary() {
+    return [NSString stringWithFormat:@"--%@%@", kHatenaAFMultipartFormBoundary, kHatenaAFMultipartFormCRLF];
+}
+
+static inline NSString * HatenaAFMultipartFormEncapsulationBoundary() {
+    return [NSString stringWithFormat:@"%@--%@%@", kHatenaAFMultipartFormCRLF, kHatenaAFMultipartFormBoundary, kHatenaAFMultipartFormCRLF];
+}
+
+static inline NSString * HatenaAFMultipartFormFinalBoundary() {
+    return [NSString stringWithFormat:@"%@--%@--%@", kHatenaAFMultipartFormCRLF, kHatenaAFMultipartFormBoundary, kHatenaAFMultipartFormCRLF];
+}
+
+static inline NSString * HatenaAFContentTypeForPathExtension(NSString *extension) {
+#ifdef __UTTYPE__
+    NSString *UTI = (__bridge_transfer NSString *)UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, (__bridge CFStringRef)extension, NULL);
+    NSString *contentType = (__bridge_transfer NSString *)UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)UTI, kUTTagClassMIMEType);
+    if (!contentType) {
+        return @"application/octet-stream";
+    } else {
+        return contentType;
+    }
+#else
+    return @"application/octet-stream";
+#endif
+}
+
+NSUInteger const kHatenaAFUploadStream3GSuggestedPacketSize = 1024 * 16;
+NSTimeInterval const kHatenaAFUploadStream3GSuggestedDelay = 0.2;
+
+@interface HatenaAFHTTPBodyPart : NSObject
+@property (nonatomic, assign) NSStringEncoding stringEncoding;
+@property (nonatomic, strong) NSDictionary *headers;
+@property (nonatomic, strong) id body;
+@property (nonatomic, assign) unsigned long long bodyContentLength;
+@property (nonatomic, strong) NSInputStream *inputStream;
+
+@property (nonatomic, assign) BOOL hasInitialBoundary;
+@property (nonatomic, assign) BOOL hasFinalBoundary;
+
+@property (nonatomic, readonly, getter = hasBytesAvailable) BOOL bytesAvailable;
+@property (nonatomic, readonly) unsigned long long contentLength;
+
+- (NSInteger)read:(uint8_t *)buffer
+        maxLength:(NSUInteger)length;
+@end
+
+@interface HatenaAFMultipartBodyStream : NSInputStream <NSStreamDelegate>
+@property (nonatomic, assign) NSUInteger numberOfBytesInPacket;
+@property (nonatomic, assign) NSTimeInterval delay;
+@property (nonatomic, strong) NSInputStream *inputStream;
+@property (nonatomic, readonly) unsigned long long contentLength;
+@property (nonatomic, readonly, getter = isEmpty) BOOL empty;
+
+- (id)initWithStringEncoding:(NSStringEncoding)encoding;
+- (void)setInitialAndFinalBoundaries;
+- (void)appendHTTPBodyPart:(HatenaAFHTTPBodyPart *)bodyPart;
+@end
+
+#pragma mark -
+
+@interface HatenaAFStreamingMultipartFormData ()
+@property (readwrite, nonatomic, copy) NSMutableURLRequest *request;
+@property (readwrite, nonatomic, strong) HatenaAFMultipartBodyStream *bodyStream;
+@property (readwrite, nonatomic, assign) NSStringEncoding stringEncoding;
+@end
+
+@implementation HatenaAFStreamingMultipartFormData
+@synthesize request = _request;
+@synthesize bodyStream = _bodyStream;
+@synthesize stringEncoding = _stringEncoding;
+
+- (id)initWithURLRequest:(NSMutableURLRequest *)urlRequest
+          stringEncoding:(NSStringEncoding)encoding
+{
+    self = [super init];
+    if (!self) {
+        return nil;
+    }
+
+    self.request = urlRequest;
+    self.stringEncoding = encoding;
+    self.bodyStream = [[HatenaAFMultipartBodyStream alloc] initWithStringEncoding:encoding];
+
+    return self;
+}
+
+- (BOOL)appendPartWithFileURL:(NSURL *)fileURL
+                         name:(NSString *)name
+                        error:(NSError * __autoreleasing *)error
+{
+    NSParameterAssert(fileURL);
+    NSParameterAssert(name);
+
+    NSString *fileName = [fileURL lastPathComponent];
+    NSString *mimeType = HatenaAFContentTypeForPathExtension([fileURL pathExtension]);
+    
+    return [self appendPartWithFileURL:fileURL name:name fileName:fileName mimeType:mimeType error:error];
+}
+
+- (BOOL)appendPartWithFileURL:(NSURL *)fileURL
+                         name:(NSString *)name
+                     fileName:(NSString *)fileName
+                     mimeType:(NSString *)mimeType
+                        error:(NSError * __autoreleasing *)error
+{
+    NSParameterAssert(fileURL);
+    NSParameterAssert(name);
+    NSParameterAssert(fileName);
+    NSParameterAssert(mimeType);
+
+    if (![fileURL isFileURL]) {
+        NSDictionary *userInfo = [NSDictionary dictionaryWithObject:NSLocalizedStringFromTable(@"Expected URL to be a file URL", @"HatenaAFNetworking", nil) forKey:NSLocalizedFailureReasonErrorKey];
+        if (error != NULL) {
+            *error = [[NSError alloc] initWithDomain:HatenaAFNetworkingErrorDomain code:NSURLErrorBadURL userInfo:userInfo];
+        }
+
+        return NO;
+    } else if ([fileURL checkResourceIsReachableAndReturnError:error] == NO) {
+        NSDictionary *userInfo = [NSDictionary dictionaryWithObject:NSLocalizedStringFromTable(@"File URL not reachable.", @"HatenaAFNetworking", nil) forKey:NSLocalizedFailureReasonErrorKey];
+        if (error != NULL) {
+            *error = [[NSError alloc] initWithDomain:HatenaAFNetworkingErrorDomain code:NSURLErrorBadURL userInfo:userInfo];
+        }
+
+        return NO;
+    }
+
+    NSMutableDictionary *mutableHeaders = [NSMutableDictionary dictionary];
+    [mutableHeaders setValue:[NSString stringWithFormat:@"form-data; name=\"%@\"; filename=\"%@\"", name, fileName] forKey:@"Content-Disposition"];
+    [mutableHeaders setValue:mimeType forKey:@"Content-Type"];
+
+    HatenaAFHTTPBodyPart *bodyPart = [[HatenaAFHTTPBodyPart alloc] init];
+    bodyPart.stringEncoding = self.stringEncoding;
+    bodyPart.headers = mutableHeaders;
+    bodyPart.body = fileURL;
+
+    NSDictionary *fileAttributes = [[NSFileManager defaultManager] attributesOfItemAtPath:[fileURL path] error:nil];
+    bodyPart.bodyContentLength = [[fileAttributes objectForKey:NSFileSize] unsignedLongLongValue];
+
+    [self.bodyStream appendHTTPBodyPart:bodyPart];
+
+    return YES;
+}
+
+
+- (void)appendPartWithInputStream:(NSInputStream *)inputStream
+                             name:(NSString *)name
+                         fileName:(NSString *)fileName
+                           length:(unsigned long long)length
+                         mimeType:(NSString *)mimeType
+{
+    NSParameterAssert(name);
+    NSParameterAssert(fileName);
+    NSParameterAssert(mimeType);
+
+    NSMutableDictionary *mutableHeaders = [NSMutableDictionary dictionary];
+    [mutableHeaders setValue:[NSString stringWithFormat:@"form-data; name=\"%@\"; filename=\"%@\"", name, fileName] forKey:@"Content-Disposition"];
+    [mutableHeaders setValue:mimeType forKey:@"Content-Type"];
+
+
+    HatenaAFHTTPBodyPart *bodyPart = [[HatenaAFHTTPBodyPart alloc] init];
+    bodyPart.stringEncoding = self.stringEncoding;
+    bodyPart.headers = mutableHeaders;
+    bodyPart.body = inputStream;
+
+    bodyPart.bodyContentLength = length;
+
+    [self.bodyStream appendHTTPBodyPart:bodyPart];
+}
+
+- (void)appendPartWithFileData:(NSData *)data
+                          name:(NSString *)name
+                      fileName:(NSString *)fileName
+                      mimeType:(NSString *)mimeType
+{
+    NSParameterAssert(name);
+    NSParameterAssert(fileName);
+    NSParameterAssert(mimeType);
+
+    NSMutableDictionary *mutableHeaders = [NSMutableDictionary dictionary];
+    [mutableHeaders setValue:[NSString stringWithFormat:@"form-data; name=\"%@\"; filename=\"%@\"", name, fileName] forKey:@"Content-Disposition"];
+    [mutableHeaders setValue:mimeType forKey:@"Content-Type"];
+
+    [self appendPartWithHeaders:mutableHeaders body:data];
+}
+
+- (void)appendPartWithFormData:(NSData *)data
+                          name:(NSString *)name
+{
+    NSParameterAssert(name);
+
+    NSMutableDictionary *mutableHeaders = [NSMutableDictionary dictionary];
+    [mutableHeaders setValue:[NSString stringWithFormat:@"form-data; name=\"%@\"", name] forKey:@"Content-Disposition"];
+
+    [self appendPartWithHeaders:mutableHeaders body:data];
+}
+
+- (void)appendPartWithHeaders:(NSDictionary *)headers
+                         body:(NSData *)body
+{
+    NSParameterAssert(body);
+
+    HatenaAFHTTPBodyPart *bodyPart = [[HatenaAFHTTPBodyPart alloc] init];
+    bodyPart.stringEncoding = self.stringEncoding;
+    bodyPart.headers = headers;
+    bodyPart.bodyContentLength = [body length];
+    bodyPart.body = body;
+
+    [self.bodyStream appendHTTPBodyPart:bodyPart];
+}
+
+- (void)throttleBandwidthWithPacketSize:(NSUInteger)numberOfBytes
+                                  delay:(NSTimeInterval)delay
+{
+    self.bodyStream.numberOfBytesInPacket = numberOfBytes;
+    self.bodyStream.delay = delay;
+}
+
+- (NSMutableURLRequest *)requestByFinalizingMultipartFormData {
+    if ([self.bodyStream isEmpty]) {
+        return self.request;
+    }
+
+    // Reset the initial and final boundaries to ensure correct Content-Length
+    [self.bodyStream setInitialAndFinalBoundaries];
+
+    [self.request setValue:[NSString stringWithFormat:@"multipart/form-data; boundary=%@", kHatenaAFMultipartFormBoundary] forHTTPHeaderField:@"Content-Type"];
+    [self.request setValue:[NSString stringWithFormat:@"%llu", [self.bodyStream contentLength]] forHTTPHeaderField:@"Content-Length"];
+    [self.request setHTTPBodyStream:self.bodyStream];
+
+    return self.request;
+}
+
+@end
+
+#pragma mark -
+
+@interface HatenaAFMultipartBodyStream () <NSCopying>
+@property (nonatomic, assign) NSStreamStatus streamStatus;
+@property (nonatomic, strong) NSError *streamError;
+@property (nonatomic, assign) NSStringEncoding stringEncoding;
+@property (nonatomic, strong) NSMutableArray *HTTPBodyParts;
+@property (nonatomic, strong) NSEnumerator *HTTPBodyPartEnumerator;
+@property (nonatomic, strong) HatenaAFHTTPBodyPart *currentHTTPBodyPart;
+@property (nonatomic, strong) NSOutputStream *outputStream;
+@property (nonatomic, strong) NSMutableData *buffer;
+@end
+
+@implementation HatenaAFMultipartBodyStream
+@synthesize streamStatus = _streamStatus;
+@synthesize streamError = _streamError;
+@synthesize stringEncoding = _stringEncoding;
+@synthesize HTTPBodyParts = _HTTPBodyParts;
+@synthesize HTTPBodyPartEnumerator = _HTTPBodyPartEnumerator;
+@synthesize currentHTTPBodyPart = _currentHTTPBodyPart;
+@synthesize inputStream = _inputStream;
+@synthesize outputStream = _outputStream;
+@synthesize buffer = _buffer;
+@synthesize numberOfBytesInPacket = _numberOfBytesInPacket;
+@synthesize delay = _delay;
+
+- (id)initWithStringEncoding:(NSStringEncoding)encoding {
+    self = [super init];
+    if (!self) {
+        return nil;
+    }
+
+    self.stringEncoding = encoding;
+    self.HTTPBodyParts = [NSMutableArray array];
+    self.numberOfBytesInPacket = NSIntegerMax;
+
+    return self;
+}
+
+- (void)setInitialAndFinalBoundaries {
+    if ([self.HTTPBodyParts count] > 0) {
+        for (HatenaAFHTTPBodyPart *bodyPart in self.HTTPBodyParts) {
+            bodyPart.hasInitialBoundary = NO;
+            bodyPart.hasFinalBoundary = NO;
+        }
+
+        [[self.HTTPBodyParts objectAtIndex:0] setHasInitialBoundary:YES];
+        [[self.HTTPBodyParts lastObject] setHasFinalBoundary:YES];
+    }
+}
+
+- (void)appendHTTPBodyPart:(HatenaAFHTTPBodyPart *)bodyPart {
+    [self.HTTPBodyParts addObject:bodyPart];
+}
+
+- (BOOL)isEmpty {
+    return [self.HTTPBodyParts count] == 0;
+}
+
+#pragma mark - NSInputStream
+
+- (NSInteger)read:(uint8_t *)buffer
+        maxLength:(NSUInteger)length
+{
+    if ([self streamStatus] == NSStreamStatusClosed) {
+        return 0;
+    }
+
+    NSInteger totalNumberOfBytesRead = 0;
+
+    while ((NSUInteger)totalNumberOfBytesRead < MIN(length, self.numberOfBytesInPacket)) {
+        if (!self.currentHTTPBodyPart || ![self.currentHTTPBodyPart hasBytesAvailable]) {
+            if (!(self.currentHTTPBodyPart = [self.HTTPBodyPartEnumerator nextObject])) {
+                break;
+            }
+        } else {
+            NSUInteger maxLength = length - (NSUInteger)totalNumberOfBytesRead;
+            NSInteger numberOfBytesRead = [self.currentHTTPBodyPart read:&buffer[totalNumberOfBytesRead] maxLength:maxLength];
+            if (numberOfBytesRead == -1) {
+                self.streamError = self.currentHTTPBodyPart.inputStream.streamError;
+                break;
+            } else {
+                totalNumberOfBytesRead += numberOfBytesRead;
+
+                if (self.delay > 0.0f) {
+                    [NSThread sleepForTimeInterval:self.delay];
+                }
+            }
+        }
+    }
+    
+    return totalNumberOfBytesRead;
+}
+
+- (BOOL)getBuffer:(__unused uint8_t **)buffer
+           length:(__unused NSUInteger *)len
+{
+    return NO;
+}
+
+- (BOOL)hasBytesAvailable {
+    return [self streamStatus] == NSStreamStatusOpen;
+}
+
+#pragma mark - NSStream
+
+- (void)open {
+    if (self.streamStatus == NSStreamStatusOpen) {
+        return;
+    }
+
+    self.streamStatus = NSStreamStatusOpen;
+
+    [self setInitialAndFinalBoundaries];
+    self.HTTPBodyPartEnumerator = [self.HTTPBodyParts objectEnumerator];
+}
+
+- (void)close {
+    self.streamStatus = NSStreamStatusClosed;
+}
+
+- (id)propertyForKey:(__unused NSString *)key {
+    return nil;
+}
+
+- (BOOL)setProperty:(__unused id)property
+             forKey:(__unused NSString *)key
+{
+    return NO;
+}
+
+- (void)scheduleInRunLoop:(__unused NSRunLoop *)aRunLoop
+                  forMode:(__unused NSString *)mode
+{}
+
+- (void)removeFromRunLoop:(__unused NSRunLoop *)aRunLoop
+                  forMode:(__unused NSString *)mode
+{}
+
+- (unsigned long long)contentLength {
+    unsigned long long length = 0;
+    for (HatenaAFHTTPBodyPart *bodyPart in self.HTTPBodyParts) {
+        length += [bodyPart contentLength];
+    }
+
+    return length;
+}
+
+#pragma mark - Undocumented CFReadStream Bridged Methods
+
+- (void)_scheduleInCFRunLoop:(__unused CFRunLoopRef)aRunLoop
+                     forMode:(__unused CFStringRef)aMode
+{}
+
+- (void)_unscheduleFromCFRunLoop:(__unused CFRunLoopRef)aRunLoop
+                         forMode:(__unused CFStringRef)aMode
+{}
+
+- (BOOL)_setCFClientFlags:(__unused CFOptionFlags)inFlags
+                 callback:(__unused CFReadStreamClientCallBack)inCallback
+                  context:(__unused CFStreamClientContext *)inContext {
+    return NO;
+}
+
+#pragma mark - NSCopying
+
+-(id)copyWithZone:(NSZone *)zone {
+    HatenaAFMultipartBodyStream *bodyStreamCopy = [[[self class] allocWithZone:zone] initWithStringEncoding:self.stringEncoding];
+
+    for (HatenaAFHTTPBodyPart *bodyPart in self.HTTPBodyParts) {
+        [bodyStreamCopy appendHTTPBodyPart:[bodyPart copy]];
+    }
+
+    [bodyStreamCopy setInitialAndFinalBoundaries];
+
+    return bodyStreamCopy;
+}
+
+@end
+
+#pragma mark -
+
+typedef enum {
+    HatenaAFEncapsulationBoundaryPhase = 1,
+    HatenaAFHeaderPhase                = 2,
+    HatenaAFBodyPhase                  = 3,
+    HatenaAFFinalBoundaryPhase         = 4,
+} HatenaAFHTTPBodyPartReadPhase;
+
+@interface HatenaAFHTTPBodyPart () <NSCopying> {
+    HatenaAFHTTPBodyPartReadPhase _phase;
+    NSInputStream *_inputStream;
+    unsigned long long _phaseReadOffset;
+}
+
+- (BOOL)transitionToNextPhase;
+- (NSInteger)readData:(NSData *)data
+           intoBuffer:(uint8_t *)buffer
+            maxLength:(NSUInteger)length;
+@end
+
+@implementation HatenaAFHTTPBodyPart
+@synthesize stringEncoding = _stringEncoding;
+@synthesize headers = _headers;
+@synthesize body = _body;
+@synthesize bodyContentLength = _bodyContentLength;
+@synthesize inputStream = _inputStream;
+@synthesize hasInitialBoundary = _hasInitialBoundary;
+@synthesize hasFinalBoundary = _hasFinalBoundary;
+
+- (id)init {
+    self = [super init];
+    if (!self) {
+        return nil;
+    }
+
+    [self transitionToNextPhase];
+
+    return self;
+}
+
+- (void)dealloc {
+    if (_inputStream) {
+        [_inputStream close];
+        _inputStream = nil;
+    }
+}
+
+- (NSInputStream *)inputStream {
+    if (!_inputStream) {
+        if ([self.body isKindOfClass:[NSData class]]) {
+            _inputStream = [NSInputStream inputStreamWithData:self.body];
+        } else if ([self.body isKindOfClass:[NSURL class]]) {
+            _inputStream = [NSInputStream inputStreamWithURL:self.body];
+        } else if ([self.body isKindOfClass:[NSInputStream class]]) {
+            _inputStream = self.body;
+        }
+    }
+
+    return _inputStream;
+}
+
+- (NSString *)stringForHeaders {
+    NSMutableString *headerString = [NSMutableString string];
+    for (NSString *field in [self.headers allKeys]) {
+        [headerString appendString:[NSString stringWithFormat:@"%@: %@%@", field, [self.headers valueForKey:field], kHatenaAFMultipartFormCRLF]];
+    }
+    [headerString appendString:kHatenaAFMultipartFormCRLF];
+
+    return [NSString stringWithString:headerString];
+}
+
+- (unsigned long long)contentLength {
+    unsigned long long length = 0;
+
+    NSData *encapsulationBoundaryData = [([self hasInitialBoundary] ? HatenaAFMultipartFormInitialBoundary() : HatenaAFMultipartFormEncapsulationBoundary()) dataUsingEncoding:self.stringEncoding];
+    length += [encapsulationBoundaryData length];
+
+    NSData *headersData = [[self stringForHeaders] dataUsingEncoding:self.stringEncoding];
+    length += [headersData length];
+
+    length += _bodyContentLength;
+
+    NSData *closingBoundaryData = ([self hasFinalBoundary] ? [HatenaAFMultipartFormFinalBoundary() dataUsingEncoding:self.stringEncoding] : [NSData data]);
+    length += [closingBoundaryData length];
+
+    return length;
+}
+
+- (BOOL)hasBytesAvailable {
+    // Allows `read:maxLength:` to be called again if `HatenaAFMultipartFormFinalBoundary` doesn't fit into the available buffer
+    if (_phase == HatenaAFFinalBoundaryPhase) {
+        return YES;
+    }
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcovered-switch-default"
+    switch (self.inputStream.streamStatus) {
+        case NSStreamStatusNotOpen:
+        case NSStreamStatusOpening:
+        case NSStreamStatusOpen:
+        case NSStreamStatusReading:
+        case NSStreamStatusWriting:
+            return YES;
+        case NSStreamStatusAtEnd:
+        case NSStreamStatusClosed:
+        case NSStreamStatusError:
+        default:
+            return NO;
+    }
+#pragma clang diagnostic pop
+}
+
+- (NSInteger)read:(uint8_t *)buffer
+        maxLength:(NSUInteger)length
+{
+    NSUInteger totalNumberOfBytesRead = 0;
+
+    if (_phase == HatenaAFEncapsulationBoundaryPhase) {
+        NSData *encapsulationBoundaryData = [([self hasInitialBoundary] ? HatenaAFMultipartFormInitialBoundary() : HatenaAFMultipartFormEncapsulationBoundary()) dataUsingEncoding:self.stringEncoding];
+        totalNumberOfBytesRead += [self readData:encapsulationBoundaryData intoBuffer:&buffer[totalNumberOfBytesRead] maxLength:(length - (NSUInteger)totalNumberOfBytesRead)];
+    }
+
+    if (_phase == HatenaAFHeaderPhase) {
+        NSData *headersData = [[self stringForHeaders] dataUsingEncoding:self.stringEncoding];
+        totalNumberOfBytesRead += [self readData:headersData intoBuffer:&buffer[totalNumberOfBytesRead] maxLength:(length - (NSUInteger)totalNumberOfBytesRead)];
+    }
+
+    if (_phase == HatenaAFBodyPhase) {
+        NSInteger numberOfBytesRead = 0;
+
+        numberOfBytesRead = [self.inputStream read:&buffer[totalNumberOfBytesRead] maxLength:(length - (NSUInteger)totalNumberOfBytesRead)];
+        if (numberOfBytesRead == -1) {
+            return -1;
+        } else {
+            totalNumberOfBytesRead += numberOfBytesRead;
+
+            if ([self.inputStream streamStatus] >= NSStreamStatusAtEnd) {
+                [self transitionToNextPhase];
+            }
+        }
+    }
+
+    if (_phase == HatenaAFFinalBoundaryPhase) {
+        NSData *closingBoundaryData = ([self hasFinalBoundary] ? [HatenaAFMultipartFormFinalBoundary() dataUsingEncoding:self.stringEncoding] : [NSData data]);
+        totalNumberOfBytesRead += [self readData:closingBoundaryData intoBuffer:&buffer[totalNumberOfBytesRead] maxLength:(length - (NSUInteger)totalNumberOfBytesRead)];
+    }
+
+    return totalNumberOfBytesRead;
+}
+
+- (NSInteger)readData:(NSData *)data
+           intoBuffer:(uint8_t *)buffer
+            maxLength:(NSUInteger)length
+{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wgnu"
+    NSRange range = NSMakeRange((NSUInteger)_phaseReadOffset, MIN([data length] - ((NSUInteger)_phaseReadOffset), length));
+    [data getBytes:buffer range:range];
+#pragma clang diagnostic pop
+
+    _phaseReadOffset += range.length;
+
+    if (((NSUInteger)_phaseReadOffset) >= [data length]) {
+        [self transitionToNextPhase];
+    }
+
+    return (NSInteger)range.length;
+}
+
+- (BOOL)transitionToNextPhase {
+    if (![[NSThread currentThread] isMainThread]) {
+        [self performSelectorOnMainThread:@selector(transitionToNextPhase) withObject:nil waitUntilDone:YES];
+        return YES;
+    }
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcovered-switch-default"
+    switch (_phase) {
+        case HatenaAFEncapsulationBoundaryPhase:
+            _phase = HatenaAFHeaderPhase;
+            break;
+        case HatenaAFHeaderPhase:
+            [self.inputStream scheduleInRunLoop:[NSRunLoop currentRunLoop] forMode:NSRunLoopCommonModes];
+            [self.inputStream open];
+            _phase = HatenaAFBodyPhase;
+            break;
+        case HatenaAFBodyPhase:
+            [self.inputStream close];
+            _phase = HatenaAFFinalBoundaryPhase;
+            break;
+        case HatenaAFFinalBoundaryPhase:
+        default:
+            _phase = HatenaAFEncapsulationBoundaryPhase;
+            break;
+    }
+    _phaseReadOffset = 0;
+#pragma clang diagnostic pop
+
+    return YES;
+}
+
+#pragma mark - NSCopying
+
+- (id)copyWithZone:(NSZone *)zone {
+    HatenaAFHTTPBodyPart *bodyPart = [[[self class] allocWithZone:zone] init];
+
+    bodyPart.stringEncoding = self.stringEncoding;
+    bodyPart.headers = self.headers;
+    bodyPart.bodyContentLength = self.bodyContentLength;
+    bodyPart.body = self.body;
+
+    return bodyPart;
+}
+
+@end

--- a/SDK/API/AFNetworking/HatenaAFHTTPClient.m
+++ b/SDK/API/AFNetworking/HatenaAFHTTPClient.m
@@ -759,20 +759,22 @@ static void HatenaAFNetworkReachabilityReleaseCallback(const void *info) {
 
 #pragma mark -
 
-static NSString * const kHatenaAFMultipartFormBoundary = @"Boundary+0xAbCdEfGbOuNdArY";
+static NSString * HatenaAFCreateMultipartFormBoundary() {
+    return [NSString stringWithFormat:@"Boundary+%08X%08X", arc4random(), arc4random()];
+}
 
 static NSString * const kHatenaAFMultipartFormCRLF = @"\r\n";
 
-static inline NSString * HatenaAFMultipartFormInitialBoundary() {
-    return [NSString stringWithFormat:@"--%@%@", kHatenaAFMultipartFormBoundary, kHatenaAFMultipartFormCRLF];
+static inline NSString * HatenaAFMultipartFormInitialBoundary(NSString *boundary) {
+    return [NSString stringWithFormat:@"--%@%@", boundary, kHatenaAFMultipartFormCRLF];
 }
 
-static inline NSString * HatenaAFMultipartFormEncapsulationBoundary() {
-    return [NSString stringWithFormat:@"%@--%@%@", kHatenaAFMultipartFormCRLF, kHatenaAFMultipartFormBoundary, kHatenaAFMultipartFormCRLF];
+static inline NSString * HatenaAFMultipartFormEncapsulationBoundary(NSString *boundary) {
+    return [NSString stringWithFormat:@"%@--%@%@", kHatenaAFMultipartFormCRLF, boundary, kHatenaAFMultipartFormCRLF];
 }
 
-static inline NSString * HatenaAFMultipartFormFinalBoundary() {
-    return [NSString stringWithFormat:@"%@--%@--%@", kHatenaAFMultipartFormCRLF, kHatenaAFMultipartFormBoundary, kHatenaAFMultipartFormCRLF];
+static inline NSString * HatenaAFMultipartFormFinalBoundary(NSString *boundary) {
+    return [NSString stringWithFormat:@"%@--%@--%@", kHatenaAFMultipartFormCRLF, boundary, kHatenaAFMultipartFormCRLF];
 }
 
 static inline NSString * HatenaAFContentTypeForPathExtension(NSString *extension) {
@@ -799,6 +801,7 @@ NSTimeInterval const kHatenaAFUploadStream3GSuggestedDelay = 0.2;
 @property (nonatomic, assign) unsigned long long bodyContentLength;
 @property (nonatomic, strong) NSInputStream *inputStream;
 
+@property (nonatomic, copy) NSString *boundary;
 @property (nonatomic, assign) BOOL hasInitialBoundary;
 @property (nonatomic, assign) BOOL hasFinalBoundary;
 
@@ -825,6 +828,7 @@ NSTimeInterval const kHatenaAFUploadStream3GSuggestedDelay = 0.2;
 
 @interface HatenaAFStreamingMultipartFormData ()
 @property (readwrite, nonatomic, copy) NSMutableURLRequest *request;
+@property (nonatomic, copy) NSString *boundary;
 @property (readwrite, nonatomic, strong) HatenaAFMultipartBodyStream *bodyStream;
 @property (readwrite, nonatomic, assign) NSStringEncoding stringEncoding;
 @end
@@ -844,6 +848,7 @@ NSTimeInterval const kHatenaAFUploadStream3GSuggestedDelay = 0.2;
 
     self.request = urlRequest;
     self.stringEncoding = encoding;
+    self.boundary = HatenaAFCreateMultipartFormBoundary();
     self.bodyStream = [[HatenaAFMultipartBodyStream alloc] initWithStringEncoding:encoding];
 
     return self;
@@ -896,6 +901,7 @@ NSTimeInterval const kHatenaAFUploadStream3GSuggestedDelay = 0.2;
     HatenaAFHTTPBodyPart *bodyPart = [[HatenaAFHTTPBodyPart alloc] init];
     bodyPart.stringEncoding = self.stringEncoding;
     bodyPart.headers = mutableHeaders;
+    bodyPart.boundary = self.boundary;
     bodyPart.body = fileURL;
 
     NSDictionary *fileAttributes = [[NSFileManager defaultManager] attributesOfItemAtPath:[fileURL path] error:nil];
@@ -925,6 +931,7 @@ NSTimeInterval const kHatenaAFUploadStream3GSuggestedDelay = 0.2;
     HatenaAFHTTPBodyPart *bodyPart = [[HatenaAFHTTPBodyPart alloc] init];
     bodyPart.stringEncoding = self.stringEncoding;
     bodyPart.headers = mutableHeaders;
+    bodyPart.boundary = self.boundary;
     bodyPart.body = inputStream;
 
     bodyPart.bodyContentLength = length;
@@ -967,6 +974,7 @@ NSTimeInterval const kHatenaAFUploadStream3GSuggestedDelay = 0.2;
     HatenaAFHTTPBodyPart *bodyPart = [[HatenaAFHTTPBodyPart alloc] init];
     bodyPart.stringEncoding = self.stringEncoding;
     bodyPart.headers = headers;
+    bodyPart.boundary = self.boundary;
     bodyPart.bodyContentLength = [body length];
     bodyPart.body = body;
 
@@ -988,7 +996,7 @@ NSTimeInterval const kHatenaAFUploadStream3GSuggestedDelay = 0.2;
     // Reset the initial and final boundaries to ensure correct Content-Length
     [self.bodyStream setInitialAndFinalBoundaries];
 
-    [self.request setValue:[NSString stringWithFormat:@"multipart/form-data; boundary=%@", kHatenaAFMultipartFormBoundary] forHTTPHeaderField:@"Content-Type"];
+    [self.request setValue:[NSString stringWithFormat:@"multipart/form-data; boundary=%@", self.boundary] forHTTPHeaderField:@"Content-Type"];
     [self.request setValue:[NSString stringWithFormat:@"%llu", [self.bodyStream contentLength]] forHTTPHeaderField:@"Content-Length"];
     [self.request setHTTPBodyStream:self.bodyStream];
 
@@ -1252,7 +1260,7 @@ typedef enum {
 - (unsigned long long)contentLength {
     unsigned long long length = 0;
 
-    NSData *encapsulationBoundaryData = [([self hasInitialBoundary] ? HatenaAFMultipartFormInitialBoundary() : HatenaAFMultipartFormEncapsulationBoundary()) dataUsingEncoding:self.stringEncoding];
+    NSData *encapsulationBoundaryData = [([self hasInitialBoundary] ? HatenaAFMultipartFormInitialBoundary(self.boundary) : HatenaAFMultipartFormEncapsulationBoundary(self.boundary)) dataUsingEncoding:self.stringEncoding];
     length += [encapsulationBoundaryData length];
 
     NSData *headersData = [[self stringForHeaders] dataUsingEncoding:self.stringEncoding];
@@ -1260,7 +1268,7 @@ typedef enum {
 
     length += _bodyContentLength;
 
-    NSData *closingBoundaryData = ([self hasFinalBoundary] ? [HatenaAFMultipartFormFinalBoundary() dataUsingEncoding:self.stringEncoding] : [NSData data]);
+    NSData *closingBoundaryData = ([self hasFinalBoundary] ? [HatenaAFMultipartFormFinalBoundary(self.boundary) dataUsingEncoding:self.stringEncoding] : [NSData data]);
     length += [closingBoundaryData length];
 
     return length;
@@ -1296,7 +1304,7 @@ typedef enum {
     NSUInteger totalNumberOfBytesRead = 0;
 
     if (_phase == HatenaAFEncapsulationBoundaryPhase) {
-        NSData *encapsulationBoundaryData = [([self hasInitialBoundary] ? HatenaAFMultipartFormInitialBoundary() : HatenaAFMultipartFormEncapsulationBoundary()) dataUsingEncoding:self.stringEncoding];
+        NSData *encapsulationBoundaryData = [([self hasInitialBoundary] ? HatenaAFMultipartFormInitialBoundary(self.boundary) : HatenaAFMultipartFormEncapsulationBoundary(self.boundary)) dataUsingEncoding:self.stringEncoding];
         totalNumberOfBytesRead += [self readData:encapsulationBoundaryData intoBuffer:&buffer[totalNumberOfBytesRead] maxLength:(length - (NSUInteger)totalNumberOfBytesRead)];
     }
 
@@ -1321,7 +1329,7 @@ typedef enum {
     }
 
     if (_phase == HatenaAFFinalBoundaryPhase) {
-        NSData *closingBoundaryData = ([self hasFinalBoundary] ? [HatenaAFMultipartFormFinalBoundary() dataUsingEncoding:self.stringEncoding] : [NSData data]);
+        NSData *closingBoundaryData = ([self hasFinalBoundary] ? [HatenaAFMultipartFormFinalBoundary(self.boundary) dataUsingEncoding:self.stringEncoding] : [NSData data]);
         totalNumberOfBytesRead += [self readData:closingBoundaryData intoBuffer:&buffer[totalNumberOfBytesRead] maxLength:(length - (NSUInteger)totalNumberOfBytesRead)];
     }
 

--- a/SDK/API/AFNetworking/HatenaAFHTTPRequestOperation.h
+++ b/SDK/API/AFNetworking/HatenaAFHTTPRequestOperation.h
@@ -1,0 +1,133 @@
+// HatenaAFHTTPRequestOperation.h
+//
+// Copyright (c) 2011 Gowalla (http://gowalla.com/)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <Foundation/Foundation.h>
+#import "HatenaAFURLConnectionOperation.h"
+
+/**
+ `HatenaAFHTTPRequestOperation` is a subclass of `HatenaAFURLConnectionOperation` for requests using the HTTP or HTTPS protocols. It encapsulates the concept of acceptable status codes and content types, which determine the success or failure of a request.
+ */
+@interface HatenaAFHTTPRequestOperation : HatenaAFURLConnectionOperation
+
+///----------------------------------------------
+/// @name Getting HTTP URL Connection Information
+///----------------------------------------------
+
+/**
+ The last HTTP response received by the operation's connection.
+ */
+@property (readonly, nonatomic, strong) NSHTTPURLResponse *response;
+
+///----------------------------------------------------------
+/// @name Managing And Checking For Acceptable HTTP Responses
+///----------------------------------------------------------
+
+/**
+ A Boolean value that corresponds to whether the status code of the response is within the specified set of acceptable status codes. Returns `YES` if `acceptableStatusCodes` is `nil`.
+ */
+@property (nonatomic, readonly) BOOL hasAcceptableStatusCode;
+
+/**
+ A Boolean value that corresponds to whether the MIME type of the response is among the specified set of acceptable content types. Returns `YES` if `acceptableContentTypes` is `nil`.
+ */
+@property (nonatomic, readonly) BOOL hasAcceptableContentType;
+
+/**
+ The callback dispatch queue on success. If `NULL` (default), the main queue is used.
+ */
+@property (nonatomic, assign) dispatch_queue_t successCallbackQueue;
+
+/**
+ The callback dispatch queue on failure. If `NULL` (default), the main queue is used.
+ */
+@property (nonatomic, assign) dispatch_queue_t failureCallbackQueue;
+
+///------------------------------------------------------------
+/// @name Managing Acceptable HTTP Status Codes & Content Types
+///------------------------------------------------------------
+
+/**
+ Returns an `NSIndexSet` object containing the ranges of acceptable HTTP status codes. When non-`nil`, the operation will set the `error` property to an error in `HatenaAFErrorDomain`. See http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html
+
+ By default, this is the range 200 to 299, inclusive.
+ */
++ (NSIndexSet *)acceptableStatusCodes;
+
+/**
+ Adds status codes to the set of acceptable HTTP status codes returned by `+acceptableStatusCodes` in subsequent calls by this class and its descendants.
+
+ @param statusCodes The status codes to be added to the set of acceptable HTTP status codes
+ */
++ (void)addAcceptableStatusCodes:(NSIndexSet *)statusCodes;
+
+/**
+ Returns an `NSSet` object containing the acceptable MIME types. When non-`nil`, the operation will set the `error` property to an error in `HatenaAFErrorDomain`. See http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.17
+
+ By default, this is `nil`.
+ */
++ (NSSet *)acceptableContentTypes;
+
+/**
+ Adds content types to the set of acceptable MIME types returned by `+acceptableContentTypes` in subsequent calls by this class and its descendants.
+
+ @param contentTypes The content types to be added to the set of acceptable MIME types
+ */
++ (void)addAcceptableContentTypes:(NSSet *)contentTypes;
+
+
+///-----------------------------------------------------
+/// @name Determining Whether A Request Can Be Processed
+///-----------------------------------------------------
+
+/**
+ A Boolean value determining whether or not the class can process the specified request. For example, `HatenaAFJSONRequestOperation` may check to make sure the content type was `application/json` or the URL path extension was `.json`.
+
+ @param urlRequest The request that is determined to be supported or not supported for this class.
+ */
++ (BOOL)canProcessRequest:(NSURLRequest *)urlRequest;
+
+///-----------------------------------------------------------
+/// @name Setting Completion Block Success / Failure Callbacks
+///-----------------------------------------------------------
+
+/**
+ Sets the `completionBlock` property with a block that executes either the specified success or failure block, depending on the state of the request on completion. If `error` returns a value, which can be caused by an unacceptable status code or content type, then `failure` is executed. Otherwise, `success` is executed.
+
+ This method should be overridden in subclasses in order to specify the response object passed into the success block.
+ 
+ @param success The block to be executed on the completion of a successful request. This block has no return value and takes two arguments: the receiver operation and the object constructed from the response data of the request.
+ @param failure The block to be executed on the completion of an unsuccessful request. This block has no return value and takes two arguments: the receiver operation and the error that occurred during the request.
+ */
+- (void)setCompletionBlockWithSuccess:(void (^)(HatenaAFHTTPRequestOperation *operation, id responseObject))success
+                              failure:(void (^)(HatenaAFHTTPRequestOperation *operation, NSError *error))failure;
+
+@end
+
+///----------------
+/// @name Functions
+///----------------
+
+/**
+ Returns a set of MIME types detected in an HTTP `Accept` or `Content-Type` header.
+ */
+extern NSSet * HatenaAFContentTypesFromHTTPHeader(NSString *string);
+

--- a/SDK/API/AFNetworking/HatenaAFHTTPRequestOperation.m
+++ b/SDK/API/AFNetworking/HatenaAFHTTPRequestOperation.m
@@ -1,0 +1,327 @@
+// HatenaAFHTTPRequestOperation.m
+//
+// Copyright (c) 2011 Gowalla (http://gowalla.com/)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "HatenaAFHTTPRequestOperation.h"
+#import <objc/runtime.h>
+
+// Workaround for change in imp_implementationWithBlock() with Xcode 4.5
+#if defined(__IPHONE_6_0) || defined(__MAC_10_8)
+#define HatenaAF_CAST_TO_BLOCK id
+#else
+#define HatenaAF_CAST_TO_BLOCK __bridge void *
+#endif
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wstrict-selector-match"
+
+NSSet * HatenaAFContentTypesFromHTTPHeader(NSString *string) {
+    if (!string) {
+        return nil;
+    }
+
+    NSArray *mediaRanges = [string componentsSeparatedByString:@","];
+    NSMutableSet *mutableContentTypes = [NSMutableSet setWithCapacity:mediaRanges.count];
+
+    [mediaRanges enumerateObjectsUsingBlock:^(NSString *mediaRange, __unused NSUInteger idx, __unused BOOL *stop) {
+        NSRange parametersRange = [mediaRange rangeOfString:@";"];
+        if (parametersRange.location != NSNotFound) {
+            mediaRange = [mediaRange substringToIndex:parametersRange.location];
+        }
+
+        mediaRange = [mediaRange stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+
+        if (mediaRange.length > 0) {
+            [mutableContentTypes addObject:mediaRange];
+        }
+    }];
+
+    return [NSSet setWithSet:mutableContentTypes];
+}
+
+static void HatenaAFGetMediaTypeAndSubtypeWithString(NSString *string, NSString **type, NSString **subtype) {
+    if (!string) {
+        return;
+    }
+
+    NSScanner *scanner = [NSScanner scannerWithString:string];
+    [scanner setCharactersToBeSkipped:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    [scanner scanUpToString:@"/" intoString:type];
+    [scanner scanString:@"/" intoString:nil];
+    [scanner scanUpToString:@";" intoString:subtype];
+}
+
+static NSString * HatenaAFStringFromIndexSet(NSIndexSet *indexSet) {
+    NSMutableString *string = [NSMutableString string];
+
+    NSRange range = NSMakeRange([indexSet firstIndex], 1);
+    while (range.location != NSNotFound) {
+        NSUInteger nextIndex = [indexSet indexGreaterThanIndex:range.location];
+        while (nextIndex == range.location + range.length) {
+            range.length++;
+            nextIndex = [indexSet indexGreaterThanIndex:nextIndex];
+        }
+
+        if (string.length) {
+            [string appendString:@","];
+        }
+
+        if (range.length == 1) {
+            [string appendFormat:@"%lu", (long)range.location];
+        } else {
+            NSUInteger firstIndex = range.location;
+            NSUInteger lastIndex = firstIndex + range.length - 1;
+            [string appendFormat:@"%lu-%lu", (long)firstIndex, (long)lastIndex];
+        }
+
+        range.location = nextIndex;
+        range.length = 1;
+    }
+
+    return string;
+}
+
+static void HatenaAFSwizzleClassMethodWithClassAndSelectorUsingBlock(Class klass, SEL selector, id block) {
+    Method originalMethod = class_getClassMethod(klass, selector);
+    IMP implementation = imp_implementationWithBlock((HatenaAF_CAST_TO_BLOCK)block);
+    class_replaceMethod(objc_getMetaClass([NSStringFromClass(klass) UTF8String]), selector, implementation, method_getTypeEncoding(originalMethod));
+}
+
+#pragma mark -
+
+@interface HatenaAFHTTPRequestOperation ()
+@property (readwrite, nonatomic, strong) NSURLRequest *request;
+@property (readwrite, nonatomic, strong) NSHTTPURLResponse *response;
+@property (readwrite, nonatomic, strong) NSError *HTTPError;
+@property (readwrite, nonatomic, strong) NSRecursiveLock *lock;
+@end
+
+@implementation HatenaAFHTTPRequestOperation
+@synthesize HTTPError = _HTTPError;
+@synthesize successCallbackQueue = _successCallbackQueue;
+@synthesize failureCallbackQueue = _failureCallbackQueue;
+@dynamic lock;
+@dynamic request;
+@dynamic response;
+
+- (void)dealloc {
+    if (_successCallbackQueue) {
+#if !OS_OBJECT_USE_OBJC
+        dispatch_release(_successCallbackQueue);
+#endif
+        _successCallbackQueue = NULL;
+    }
+
+    if (_failureCallbackQueue) {
+#if !OS_OBJECT_USE_OBJC
+        dispatch_release(_failureCallbackQueue);
+#endif
+        _failureCallbackQueue = NULL;
+    }
+}
+
+- (NSError *)error {
+    [self.lock lock];
+    if (!self.HTTPError && self.response) {
+        if (![self hasAcceptableStatusCode] || ![self hasAcceptableContentType]) {
+            NSMutableDictionary *userInfo = [NSMutableDictionary dictionary];
+            [userInfo setValue:self.responseString forKey:NSLocalizedRecoverySuggestionErrorKey];
+            [userInfo setValue:[self.request URL] forKey:NSURLErrorFailingURLErrorKey];
+            [userInfo setValue:self.request forKey:HatenaAFNetworkingOperationFailingURLRequestErrorKey];
+            [userInfo setValue:self.response forKey:HatenaAFNetworkingOperationFailingURLResponseErrorKey];
+
+            if (![self hasAcceptableStatusCode]) {
+                NSInteger statusCode = ([self.response isKindOfClass:[NSHTTPURLResponse class]]) ? [self.response statusCode] : 200;
+                [userInfo setValue:[NSString stringWithFormat:NSLocalizedStringFromTable(@"Expected status code in (%@), got %ld", @"HatenaAFNetworking", nil), HatenaAFStringFromIndexSet([[self class] acceptableStatusCodes]), (long)statusCode] forKey:NSLocalizedDescriptionKey];
+                self.HTTPError = [[NSError alloc] initWithDomain:HatenaAFNetworkingErrorDomain code:NSURLErrorBadServerResponse userInfo:userInfo];
+            } else if (![self hasAcceptableContentType]) {
+                // Don't invalidate content type if there is no content
+                if ([self.responseData length] > 0) {
+                    [userInfo setValue:[NSString stringWithFormat:NSLocalizedStringFromTable(@"Expected content type %@, got %@", @"HatenaAFNetworking", nil), [[self class] acceptableContentTypes], [self.response MIMEType]] forKey:NSLocalizedDescriptionKey];
+                    self.HTTPError = [[NSError alloc] initWithDomain:HatenaAFNetworkingErrorDomain code:NSURLErrorCannotDecodeContentData userInfo:userInfo];
+                }
+            }
+        }
+    }
+    [self.lock unlock];
+
+    if (self.HTTPError) {
+        return self.HTTPError;
+    } else {
+        return [super error];
+    }
+}
+
+- (NSStringEncoding)responseStringEncoding {
+    // When no explicit charset parameter is provided by the sender, media subtypes of the "text" type are defined to have a default charset value of "ISO-8859-1" when received via HTTP. Data in character sets other than "ISO-8859-1" or its subsets MUST be labeled with an appropriate charset value.
+    // See http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.4.1
+    if (self.response && !self.response.textEncodingName && self.responseData && [self.response respondsToSelector:@selector(allHeaderFields)]) {
+        NSString *type = nil;
+        HatenaAFGetMediaTypeAndSubtypeWithString([[self.response allHeaderFields] valueForKey:@"Content-Type"], &type, nil);
+
+        if ([type isEqualToString:@"text"]) {
+            return NSISOLatin1StringEncoding;
+        }
+    }
+
+    return [super responseStringEncoding];
+}
+
+- (void)pause {
+    unsigned long long offset = 0;
+    if ([self.outputStream propertyForKey:NSStreamFileCurrentOffsetKey]) {
+        offset = [[self.outputStream propertyForKey:NSStreamFileCurrentOffsetKey] unsignedLongLongValue];
+    } else {
+        offset = [[self.outputStream propertyForKey:NSStreamDataWrittenToMemoryStreamKey] length];
+    }
+
+    NSMutableURLRequest *mutableURLRequest = [self.request mutableCopy];
+    if ([self.response respondsToSelector:@selector(allHeaderFields)] && [[self.response allHeaderFields] valueForKey:@"ETag"]) {
+        [mutableURLRequest setValue:[[self.response allHeaderFields] valueForKey:@"ETag"] forHTTPHeaderField:@"If-Range"];
+    }
+    [mutableURLRequest setValue:[NSString stringWithFormat:@"bytes=%llu-", offset] forHTTPHeaderField:@"Range"];
+    self.request = mutableURLRequest;
+
+    [super pause];
+}
+
+- (BOOL)hasAcceptableStatusCode {
+	if (!self.response) {
+		return NO;
+	}
+
+    NSUInteger statusCode = ([self.response isKindOfClass:[NSHTTPURLResponse class]]) ? (NSUInteger)[self.response statusCode] : 200;
+    return ![[self class] acceptableStatusCodes] || [[[self class] acceptableStatusCodes] containsIndex:statusCode];
+}
+
+- (BOOL)hasAcceptableContentType {
+    if (!self.response) {
+		return NO;
+	}
+
+    // Any HTTP/1.1 message containing an entity-body SHOULD include a Content-Type header field defining the media type of that body. If and only if the media type is not given by a Content-Type field, the recipient MAY attempt to guess the media type via inspection of its content and/or the name extension(s) of the URI used to identify the resource. If the media type remains unknown, the recipient SHOULD treat it as type "application/octet-stream".
+    // See http://www.w3.org/Protocols/rfc2616/rfc2616-sec7.html
+    NSString *contentType = [self.response MIMEType];
+    if (!contentType) {
+        contentType = @"application/octet-stream";
+    }
+
+    return ![[self class] acceptableContentTypes] || [[[self class] acceptableContentTypes] containsObject:contentType];
+}
+
+- (void)setSuccessCallbackQueue:(dispatch_queue_t)successCallbackQueue {
+    if (successCallbackQueue != _successCallbackQueue) {
+        if (_successCallbackQueue) {
+#if !OS_OBJECT_USE_OBJC
+            dispatch_release(_successCallbackQueue);
+#endif
+            _successCallbackQueue = NULL;
+        }
+
+        if (successCallbackQueue) {
+#if !OS_OBJECT_USE_OBJC
+            dispatch_retain(successCallbackQueue);
+#endif
+            _successCallbackQueue = successCallbackQueue;
+        }
+    }
+}
+
+- (void)setFailureCallbackQueue:(dispatch_queue_t)failureCallbackQueue {
+    if (failureCallbackQueue != _failureCallbackQueue) {
+        if (_failureCallbackQueue) {
+#if !OS_OBJECT_USE_OBJC
+            dispatch_release(_failureCallbackQueue);
+#endif
+            _failureCallbackQueue = NULL;
+        }
+
+        if (failureCallbackQueue) {
+#if !OS_OBJECT_USE_OBJC
+            dispatch_retain(failureCallbackQueue);
+#endif
+            _failureCallbackQueue = failureCallbackQueue;
+        }
+    }
+}
+
+- (void)setCompletionBlockWithSuccess:(void (^)(HatenaAFHTTPRequestOperation *operation, id responseObject))success
+                              failure:(void (^)(HatenaAFHTTPRequestOperation *operation, NSError *error))failure
+{
+    // completionBlock is manually nilled out in HatenaAFURLConnectionOperation to break the retain cycle.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-retain-cycles"
+#pragma clang diagnostic ignored "-Wgnu"
+    self.completionBlock = ^{
+        if (self.error) {
+            if (failure) {
+                dispatch_async(self.failureCallbackQueue ?: dispatch_get_main_queue(), ^{
+                    failure(self, self.error);
+                });
+            }
+        } else {
+            if (success) {
+                dispatch_async(self.successCallbackQueue ?: dispatch_get_main_queue(), ^{
+                    success(self, self.responseData);
+                });
+            }
+        }
+    };
+#pragma clang diagnostic pop
+}
+
+#pragma mark - HatenaAFHTTPRequestOperation
+
++ (NSIndexSet *)acceptableStatusCodes {
+    return [NSIndexSet indexSetWithIndexesInRange:NSMakeRange(200, 100)];
+}
+
++ (void)addAcceptableStatusCodes:(NSIndexSet *)statusCodes {
+    NSMutableIndexSet *mutableStatusCodes = [[NSMutableIndexSet alloc] initWithIndexSet:[self acceptableStatusCodes]];
+    [mutableStatusCodes addIndexes:statusCodes];
+    HatenaAFSwizzleClassMethodWithClassAndSelectorUsingBlock([self class], @selector(acceptableStatusCodes), ^(__unused id _self) {
+        return mutableStatusCodes;
+    });
+}
+
++ (NSSet *)acceptableContentTypes {
+    return nil;
+}
+
++ (void)addAcceptableContentTypes:(NSSet *)contentTypes {
+    NSMutableSet *mutableContentTypes = [[NSMutableSet alloc] initWithSet:[self acceptableContentTypes] copyItems:YES];
+    [mutableContentTypes unionSet:contentTypes];
+    HatenaAFSwizzleClassMethodWithClassAndSelectorUsingBlock([self class], @selector(acceptableContentTypes), ^(__unused id _self) {
+        return mutableContentTypes;
+    });
+}
+
++ (BOOL)canProcessRequest:(NSURLRequest *)request {
+    if ([[self class] isEqual:[HatenaAFHTTPRequestOperation class]]) {
+        return YES;
+    }
+
+    return [[self acceptableContentTypes] intersectsSet:HatenaAFContentTypesFromHTTPHeader([request valueForHTTPHeaderField:@"Accept"])];
+}
+
+@end
+
+#pragma clang diagnostic pop

--- a/SDK/API/AFNetworking/HatenaAFImageRequestOperation.h
+++ b/SDK/API/AFNetworking/HatenaAFImageRequestOperation.h
@@ -1,0 +1,113 @@
+// HatenaAFImageRequestOperation.h
+//
+// Copyright (c) 2011 Gowalla (http://gowalla.com/)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <Foundation/Foundation.h>
+#import "HatenaAFHTTPRequestOperation.h"
+
+#import <Availability.h>
+
+#if defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
+#import <UIKit/UIKit.h>
+#elif defined(__MAC_OS_X_VERSION_MIN_REQUIRED)
+#import <Cocoa/Cocoa.h>
+#endif
+
+/**
+ `HatenaAFImageRequestOperation` is a subclass of `HatenaAFHTTPRequestOperation` for downloading and processing images.
+
+ ## Acceptable Content Types
+
+ By default, `HatenaAFImageRequestOperation` accepts the following MIME types, which correspond to the image formats supported by UIImage or NSImage:
+
+ - `image/tiff`
+ - `image/jpeg`
+ - `image/gif`
+ - `image/png`
+ - `image/ico`
+ - `image/x-icon`
+ - `image/bmp`
+ - `image/x-bmp`
+ - `image/x-xbitmap`
+ - `image/x-win-bitmap`
+ */
+@interface HatenaAFImageRequestOperation : HatenaAFHTTPRequestOperation
+
+/**
+ An image constructed from the response data. If an error occurs during the request, `nil` will be returned, and the `error` property will be set to the error.
+ */
+#if defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
+@property (readonly, nonatomic, strong) UIImage *responseImage;
+#elif defined(__MAC_OS_X_VERSION_MIN_REQUIRED)
+@property (readonly, nonatomic, strong) NSImage *responseImage;
+#endif
+
+#if defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
+/**
+ The scale factor used when interpreting the image data to construct `responseImage`. Specifying a scale factor of 1.0 results in an image whose size matches the pixel-based dimensions of the image. Applying a different scale factor changes the size of the image as reported by the size property. This is set to the value of scale of the main screen by default, which automatically scales images for retina displays, for instance.
+ */
+@property (nonatomic, assign) CGFloat imageScale;
+
+/**
+ Whether to automatically inflate response image data for compressed formats (such as PNG or JPEG). Enabling this can significantly improve drawing performance on iOS when used with `setCompletionBlockWithSuccess:failure:`, as it allows a bitmap representation to be constructed in the background rather than on the main thread. `YES` by default.
+ */
+@property (nonatomic, assign) BOOL automaticallyInflatesResponseImage;
+#endif
+
+/**
+ Creates and returns an `HatenaAFImageRequestOperation` object and sets the specified success callback.
+
+ @param urlRequest The request object to be loaded asynchronously during execution of the operation.
+ @param success A block object to be executed when the request finishes successfully. This block has no return value and takes a single argument, the image created from the response data of the request.
+
+ @return A new image request operation
+ */
+#if defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
++ (instancetype)imageRequestOperationWithRequest:(NSURLRequest *)urlRequest
+										 success:(void (^)(UIImage *image))success;
+#elif defined(__MAC_OS_X_VERSION_MIN_REQUIRED)
++ (instancetype)imageRequestOperationWithRequest:(NSURLRequest *)urlRequest
+										 success:(void (^)(NSImage *image))success;
+#endif
+
+/**
+ Creates and returns an `HatenaAFImageRequestOperation` object and sets the specified success callback.
+
+ @param urlRequest The request object to be loaded asynchronously during execution of the operation.
+ @param imageProcessingBlock A block object to be executed after the image request finishes successfully, but before the image is returned in the `success` block. This block takes a single argument, the image loaded from the response body, and returns the processed image.
+ @param success A block object to be executed when the request finishes successfully, with a status code in the 2xx range, and with an acceptable content type (e.g. `image/png`). This block has no return value and takes three arguments: the request object of the operation, the response for the request, and the image created from the response data.
+ @param failure A block object to be executed when the request finishes unsuccessfully. This block has no return value and takes three arguments: the request object of the operation, the response for the request, and the error associated with the cause for the unsuccessful operation.
+
+ @return A new image request operation
+ */
+#if defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
++ (instancetype)imageRequestOperationWithRequest:(NSURLRequest *)urlRequest
+							imageProcessingBlock:(UIImage *(^)(UIImage *image))imageProcessingBlock
+										 success:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, UIImage *image))success
+										 failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error))failure;
+#elif defined(__MAC_OS_X_VERSION_MIN_REQUIRED)
++ (instancetype)imageRequestOperationWithRequest:(NSURLRequest *)urlRequest
+							imageProcessingBlock:(NSImage *(^)(NSImage *image))imageProcessingBlock
+										 success:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSImage *image))success
+										 failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error))failure;
+#endif
+
+@end

--- a/SDK/API/AFNetworking/HatenaAFImageRequestOperation.m
+++ b/SDK/API/AFNetworking/HatenaAFImageRequestOperation.m
@@ -1,0 +1,321 @@
+// HatenaAFImageRequestOperation.m
+//
+// Copyright (c) 2011 Gowalla (http://gowalla.com/)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "HatenaAFImageRequestOperation.h"
+
+static dispatch_queue_t image_request_operation_processing_queue() {
+    static dispatch_queue_t af_image_request_operation_processing_queue;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        af_image_request_operation_processing_queue = dispatch_queue_create("com.alamofire.networking.image-request.processing", DISPATCH_QUEUE_CONCURRENT);
+    });
+
+    return af_image_request_operation_processing_queue;
+}
+
+#if defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
+#import <CoreGraphics/CoreGraphics.h>
+
+static UIImage * HatenaAFImageWithDataAtScale(NSData *data, CGFloat scale) {
+    UIImage *image = [[UIImage alloc] initWithData:data];
+    
+    return [[UIImage alloc] initWithCGImage:[image CGImage] scale:scale orientation:image.imageOrientation];
+}
+
+static UIImage * HatenaAFInflatedImageFromResponseWithDataAtScale(NSHTTPURLResponse *response, NSData *data, CGFloat scale) {
+    if (!data || [data length] == 0) {
+        return nil;
+    }
+
+    UIImage *image = HatenaAFImageWithDataAtScale(data, scale);
+    if (image.images) {
+        return image;
+    }
+    
+    CGImageRef imageRef = nil;
+    CGDataProviderRef dataProvider = CGDataProviderCreateWithCFData((__bridge CFDataRef)data);
+
+    if ([response.MIMEType isEqualToString:@"image/png"]) {
+        imageRef = CGImageCreateWithPNGDataProvider(dataProvider,  NULL, true, kCGRenderingIntentDefault);
+    } else if ([response.MIMEType isEqualToString:@"image/jpeg"]) {
+        imageRef = CGImageCreateWithJPEGDataProvider(dataProvider, NULL, true, kCGRenderingIntentDefault);
+    }
+    
+    if (!imageRef) {
+        imageRef = CGImageCreateCopy([image CGImage]);
+
+        if (!imageRef) {
+            CGDataProviderRelease(dataProvider);
+            return image;
+        }
+    }
+
+    CGDataProviderRelease(dataProvider);
+
+    size_t width = CGImageGetWidth(imageRef);
+    size_t height = CGImageGetHeight(imageRef);
+    size_t bitsPerComponent = CGImageGetBitsPerComponent(imageRef);
+    size_t bytesPerRow = 0; // CGImageGetBytesPerRow() calculates incorrectly in iOS 5.0, so defer to CGBitmapContextCreate()
+    CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
+    CGBitmapInfo bitmapInfo = CGImageGetBitmapInfo(imageRef);
+
+    if (CGColorSpaceGetNumberOfComponents(colorSpace) == 3) {
+        int alpha = (bitmapInfo & kCGBitmapAlphaInfoMask);
+        if (alpha == kCGImageAlphaNone) {
+            bitmapInfo &= ~kCGBitmapAlphaInfoMask;
+            bitmapInfo |= kCGImageAlphaNoneSkipFirst;
+        } else if (!(alpha == kCGImageAlphaNoneSkipFirst || alpha == kCGImageAlphaNoneSkipLast)) {
+            bitmapInfo &= ~kCGBitmapAlphaInfoMask;
+            bitmapInfo |= kCGImageAlphaPremultipliedFirst;
+        }
+    }
+
+    CGContextRef context = CGBitmapContextCreate(NULL, width, height, bitsPerComponent, bytesPerRow, colorSpace, bitmapInfo);
+
+    CGColorSpaceRelease(colorSpace);
+
+    if (!context) {
+        CGImageRelease(imageRef);
+
+        return image;
+    }
+
+    CGRect rect = CGRectMake(0.0f, 0.0f, width, height);
+    CGContextDrawImage(context, rect, imageRef);
+    CGImageRef inflatedImageRef = CGBitmapContextCreateImage(context);
+    CGContextRelease(context);
+
+    UIImage *inflatedImage = [[UIImage alloc] initWithCGImage:inflatedImageRef scale:scale orientation:image.imageOrientation];
+    CGImageRelease(inflatedImageRef);
+    CGImageRelease(imageRef);
+    
+    return inflatedImage;
+}
+#endif
+
+@interface HatenaAFImageRequestOperation ()
+#if defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
+@property (readwrite, nonatomic, strong) UIImage *responseImage;
+#elif defined(__MAC_OS_X_VERSION_MIN_REQUIRED)
+@property (readwrite, nonatomic, strong) NSImage *responseImage;
+#endif
+@end
+
+@implementation HatenaAFImageRequestOperation
+@synthesize responseImage = _responseImage;
+#if defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
+@synthesize imageScale = _imageScale;
+#endif
+
+#if defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
++ (instancetype)imageRequestOperationWithRequest:(NSURLRequest *)urlRequest
+										 success:(void (^)(UIImage *image))success
+{
+    return [self imageRequestOperationWithRequest:urlRequest imageProcessingBlock:nil success:^(NSURLRequest __unused *request, NSHTTPURLResponse __unused *response, UIImage *image) {
+        if (success) {
+            success(image);
+        }
+    } failure:nil];
+}
+#elif defined(__MAC_OS_X_VERSION_MIN_REQUIRED)
++ (instancetype)imageRequestOperationWithRequest:(NSURLRequest *)urlRequest
+										 success:(void (^)(NSImage *image))success
+{
+    return [self imageRequestOperationWithRequest:urlRequest imageProcessingBlock:nil success:^(NSURLRequest __unused *request, NSHTTPURLResponse __unused *response, NSImage *image) {
+        if (success) {
+            success(image);
+        }
+    } failure:nil];
+}
+#endif
+
+
+#if defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
++ (instancetype)imageRequestOperationWithRequest:(NSURLRequest *)urlRequest
+							imageProcessingBlock:(UIImage *(^)(UIImage *))imageProcessingBlock
+										 success:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, UIImage *image))success
+										 failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error))failure
+{
+    HatenaAFImageRequestOperation *requestOperation = [(HatenaAFImageRequestOperation *)[self alloc] initWithRequest:urlRequest];
+    [requestOperation setCompletionBlockWithSuccess:^(HatenaAFHTTPRequestOperation *operation, id responseObject) {
+        if (success) {
+            UIImage *image = responseObject;
+            if (imageProcessingBlock) {
+                dispatch_async(image_request_operation_processing_queue(), ^(void) {
+                    UIImage *processedImage = imageProcessingBlock(image);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wgnu"
+                    dispatch_async(operation.successCallbackQueue ?: dispatch_get_main_queue(), ^(void) {
+                        success(operation.request, operation.response, processedImage);
+                    });
+#pragma clang diagnostic pop
+                });
+            } else {
+                success(operation.request, operation.response, image);
+            }
+        }
+    } failure:^(HatenaAFHTTPRequestOperation *operation, NSError *error) {
+        if (failure) {
+            failure(operation.request, operation.response, error);
+        }
+    }];
+
+
+    return requestOperation;
+}
+#elif defined(__MAC_OS_X_VERSION_MIN_REQUIRED)
++ (instancetype)imageRequestOperationWithRequest:(NSURLRequest *)urlRequest
+							imageProcessingBlock:(NSImage *(^)(NSImage *))imageProcessingBlock
+										 success:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSImage *image))success
+										 failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error))failure
+{
+    HatenaAFImageRequestOperation *requestOperation = [(HatenaAFImageRequestOperation *)[self alloc] initWithRequest:urlRequest];
+    [requestOperation setCompletionBlockWithSuccess:^(HatenaAFHTTPRequestOperation *operation, id responseObject) {
+        if (success) {
+            NSImage *image = responseObject;
+            if (imageProcessingBlock) {
+                dispatch_async(image_request_operation_processing_queue(), ^(void) {
+                    NSImage *processedImage = imageProcessingBlock(image);
+
+                    dispatch_async(operation.successCallbackQueue ?: dispatch_get_main_queue(), ^(void) {
+                        success(operation.request, operation.response, processedImage);
+                    });
+                });
+            } else {
+                success(operation.request, operation.response, image);
+            }
+        }
+    } failure:^(HatenaAFHTTPRequestOperation *operation, NSError *error) {
+        if (failure) {
+            failure(operation.request, operation.response, error);
+        }
+    }];
+
+    return requestOperation;
+}
+#endif
+
+- (id)initWithRequest:(NSURLRequest *)urlRequest {
+    self = [super initWithRequest:urlRequest];
+    if (!self) {
+        return nil;
+    }
+
+#if defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
+    self.imageScale = [[UIScreen mainScreen] scale];
+    self.automaticallyInflatesResponseImage = YES;
+#endif
+
+    return self;
+}
+
+
+#if defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
+- (UIImage *)responseImage {
+    if (!_responseImage && [self.responseData length] > 0 && [self isFinished]) {
+        if (self.automaticallyInflatesResponseImage) {
+            self.responseImage = HatenaAFInflatedImageFromResponseWithDataAtScale(self.response, self.responseData, self.imageScale);
+        } else {
+            self.responseImage = HatenaAFImageWithDataAtScale(self.responseData, self.imageScale);
+        }
+    }
+
+    return _responseImage;
+}
+
+- (void)setImageScale:(CGFloat)imageScale {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wfloat-equal"
+    if (imageScale == _imageScale) {
+        return;
+    }
+#pragma clang diagnostic pop
+
+    _imageScale = imageScale;
+
+    self.responseImage = nil;
+}
+#elif defined(__MAC_OS_X_VERSION_MIN_REQUIRED)
+- (NSImage *)responseImage {
+    if (!_responseImage && [self.responseData length] > 0 && [self isFinished]) {
+        // Ensure that the image is set to it's correct pixel width and height
+        NSBitmapImageRep *bitimage = [[NSBitmapImageRep alloc] initWithData:self.responseData];
+        self.responseImage = [[NSImage alloc] initWithSize:NSMakeSize([bitimage pixelsWide], [bitimage pixelsHigh])];
+        [self.responseImage addRepresentation:bitimage];
+    }
+
+    return _responseImage;
+}
+#endif
+
+#pragma mark - HatenaAFHTTPRequestOperation
+
++ (NSSet *)acceptableContentTypes {
+    return [NSSet setWithObjects:@"image/tiff", @"image/jpeg", @"image/gif", @"image/png", @"image/ico", @"image/x-icon", @"image/bmp", @"image/x-bmp", @"image/x-xbitmap", @"image/x-win-bitmap", nil];
+}
+
++ (BOOL)canProcessRequest:(NSURLRequest *)request {
+    static NSSet * _acceptablePathExtension = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        _acceptablePathExtension = [[NSSet alloc] initWithObjects:@"tif", @"tiff", @"jpg", @"jpeg", @"gif", @"png", @"ico", @"bmp", @"cur", nil];
+    });
+
+    return [_acceptablePathExtension containsObject:[[request URL] pathExtension]] || [super canProcessRequest:request];
+}
+
+- (void)setCompletionBlockWithSuccess:(void (^)(HatenaAFHTTPRequestOperation *operation, id responseObject))success
+                              failure:(void (^)(HatenaAFHTTPRequestOperation *operation, NSError *error))failure
+{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-retain-cycles"
+#pragma clang diagnostic ignored "-Wgnu"
+
+    self.completionBlock = ^ {
+        dispatch_async(image_request_operation_processing_queue(), ^(void) {
+            if (self.error) {
+                if (failure) {
+                    dispatch_async(self.failureCallbackQueue ?: dispatch_get_main_queue(), ^{
+                        failure(self, self.error);
+                    });
+                }
+            } else {
+                if (success) {
+#if defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
+                    UIImage *image = nil;
+#elif defined(__MAC_OS_X_VERSION_MIN_REQUIRED)
+                    NSImage *image = nil;
+#endif
+
+                    image = self.responseImage;
+
+                    dispatch_async(self.successCallbackQueue ?: dispatch_get_main_queue(), ^{
+                        success(self, image);
+                    });
+                }
+            }
+        });
+    };
+#pragma clang diagnostic pop
+}
+
+@end

--- a/SDK/API/AFNetworking/HatenaAFJSONRequestOperation.h
+++ b/SDK/API/AFNetworking/HatenaAFJSONRequestOperation.h
@@ -1,0 +1,71 @@
+// HatenaAFJSONRequestOperation.h
+//
+// Copyright (c) 2011 Gowalla (http://gowalla.com/)
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <Foundation/Foundation.h>
+#import "HatenaAFHTTPRequestOperation.h"
+
+/**
+ `HatenaAFJSONRequestOperation` is a subclass of `HatenaAFHTTPRequestOperation` for downloading and working with JSON response data.
+ 
+ ## Acceptable Content Types
+ 
+ By default, `HatenaAFJSONRequestOperation` accepts the following MIME types, which includes the official standard, `application/json`, as well as other commonly-used types:
+ 
+ - `application/json`
+ - `text/json`
+
+ @warning JSON parsing will use the built-in `NSJSONSerialization` class.
+ */
+@interface HatenaAFJSONRequestOperation : HatenaAFHTTPRequestOperation
+
+///----------------------------
+/// @name Getting Response Data
+///----------------------------
+
+/**
+ A JSON object constructed from the response data. If an error occurs while parsing, `nil` will be returned, and the `error` property will be set to the error.
+ */
+@property (readonly, nonatomic, strong) id responseJSON;
+
+/**
+ Options for reading the response JSON data and creating the Foundation objects. For possible values, see the `NSJSONSerialization` documentation section "NSJSONReadingOptions".
+ */
+@property (nonatomic, assign) NSJSONReadingOptions JSONReadingOptions;
+ 
+///----------------------------------
+/// @name Creating Request Operations
+///----------------------------------
+
+/**
+ Creates and returns an `HatenaAFJSONRequestOperation` object and sets the specified success and failure callbacks.
+ 
+ @param urlRequest The request object to be loaded asynchronously during execution of the operation
+ @param success A block object to be executed when the operation finishes successfully. This block has no return value and takes three arguments: the request sent from the client, the response received from the server, and the JSON object created from the response data of request.
+ @param failure A block object to be executed when the operation finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the response data as JSON. This block has no return value and takes three arguments: the request sent from the client, the response received from the server, and the error describing the network or parsing error that occurred.
+  
+ @return A new JSON request operation
+ */
++ (instancetype)JSONRequestOperationWithRequest:(NSURLRequest *)urlRequest
+                                        success:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, id JSON))success
+                                        failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error, id JSON))failure;
+
+@end

--- a/SDK/API/AFNetworking/HatenaAFJSONRequestOperation.m
+++ b/SDK/API/AFNetworking/HatenaAFJSONRequestOperation.m
@@ -1,0 +1,150 @@
+// HatenaAFJSONRequestOperation.m
+//
+// Copyright (c) 2011 Gowalla (http://gowalla.com/)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "HatenaAFJSONRequestOperation.h"
+
+static dispatch_queue_t json_request_operation_processing_queue() {
+    static dispatch_queue_t af_json_request_operation_processing_queue;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        af_json_request_operation_processing_queue = dispatch_queue_create("com.alamofire.networking.json-request.processing", DISPATCH_QUEUE_CONCURRENT);
+    });
+
+    return af_json_request_operation_processing_queue;
+}
+
+@interface HatenaAFJSONRequestOperation ()
+@property (readwrite, nonatomic, strong) id responseJSON;
+@property (readwrite, nonatomic, strong) NSError *JSONError;
+@property (readwrite, nonatomic, strong) NSRecursiveLock *lock;
+@end
+
+@implementation HatenaAFJSONRequestOperation
+@synthesize responseJSON = _responseJSON;
+@synthesize JSONReadingOptions = _JSONReadingOptions;
+@synthesize JSONError = _JSONError;
+@dynamic lock;
+
++ (instancetype)JSONRequestOperationWithRequest:(NSURLRequest *)urlRequest
+										success:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, id JSON))success
+										failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error, id JSON))failure
+{
+    HatenaAFJSONRequestOperation *requestOperation = [(HatenaAFJSONRequestOperation *)[self alloc] initWithRequest:urlRequest];
+    [requestOperation setCompletionBlockWithSuccess:^(HatenaAFHTTPRequestOperation *operation, id responseObject) {
+        if (success) {
+            success(operation.request, operation.response, responseObject);
+        }
+    } failure:^(HatenaAFHTTPRequestOperation *operation, NSError *error) {
+        if (failure) {
+            failure(operation.request, operation.response, error, [(HatenaAFJSONRequestOperation *)operation responseJSON]);
+        }
+    }];
+
+    return requestOperation;
+}
+
+
+- (id)responseJSON {
+    [self.lock lock];
+    if (!_responseJSON && [self.responseData length] > 0 && [self isFinished] && !self.JSONError) {
+        NSError *error = nil;
+
+        // Workaround for behavior of Rails to return a single space for `head :ok` (a workaround for a bug in Safari), which is not interpreted as valid input by NSJSONSerialization.
+        // See https://github.com/rails/rails/issues/1742
+        if (self.responseString && ![self.responseString isEqualToString:@" "]) {
+            // Workaround for a bug in NSJSONSerialization when Unicode character escape codes are used instead of the actual character
+            // See http://stackoverflow.com/a/12843465/157142
+            NSData *data = [self.responseString dataUsingEncoding:NSUTF8StringEncoding];
+
+            if (data) {
+                self.responseJSON = [NSJSONSerialization JSONObjectWithData:data options:self.JSONReadingOptions error:&error];
+            } else {
+                NSMutableDictionary *userInfo = [NSMutableDictionary dictionary];
+                [userInfo setValue:@"Operation responseData failed decoding as a UTF-8 string" forKey:NSLocalizedDescriptionKey];
+                [userInfo setValue:[NSString stringWithFormat:@"Could not decode string: %@", self.responseString] forKey:NSLocalizedFailureReasonErrorKey];
+                error = [[NSError alloc] initWithDomain:HatenaAFNetworkingErrorDomain code:NSURLErrorCannotDecodeContentData userInfo:userInfo];
+            }
+        }
+
+        self.JSONError = error;
+    }
+    [self.lock unlock];
+
+    return _responseJSON;
+}
+
+- (NSError *)error {
+    if (_JSONError) {
+        return _JSONError;
+    } else {
+        return [super error];
+    }
+}
+
+#pragma mark - HatenaAFHTTPRequestOperation
+
++ (NSSet *)acceptableContentTypes {
+    return [NSSet setWithObjects:@"application/json", @"text/json", @"text/javascript", nil];
+}
+
++ (BOOL)canProcessRequest:(NSURLRequest *)request {
+    return [[[request URL] pathExtension] isEqualToString:@"json"] || [super canProcessRequest:request];
+}
+
+- (void)setCompletionBlockWithSuccess:(void (^)(HatenaAFHTTPRequestOperation *operation, id responseObject))success
+                              failure:(void (^)(HatenaAFHTTPRequestOperation *operation, NSError *error))failure
+{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-retain-cycles"
+#pragma clang diagnostic ignored "-Wgnu"
+
+    self.completionBlock = ^ {
+        if (self.error) {
+            if (failure) {
+                dispatch_async(self.failureCallbackQueue ?: dispatch_get_main_queue(), ^{
+                    failure(self, self.error);
+                });
+            }
+        } else {
+            dispatch_async(json_request_operation_processing_queue(), ^{
+                id JSON = self.responseJSON;
+
+                if (self.error) {
+                    if (failure) {
+                        dispatch_async(self.failureCallbackQueue ?: dispatch_get_main_queue(), ^{
+                            failure(self, self.error);
+                        });
+                    }
+                } else {
+                    if (success) {
+                        dispatch_async(self.successCallbackQueue ?: dispatch_get_main_queue(), ^{
+                            success(self, JSON);
+                        });
+                    }
+                }
+            });
+        }
+    };
+#pragma clang diagnostic pop
+}
+
+@end

--- a/SDK/API/AFNetworking/HatenaAFNetworkActivityIndicatorManager.h
+++ b/SDK/API/AFNetworking/HatenaAFNetworkActivityIndicatorManager.h
@@ -1,0 +1,75 @@
+// HatenaAFNetworkActivityIndicatorManager.h
+//
+// Copyright (c) 2011 Gowalla (http://gowalla.com/)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <Foundation/Foundation.h>
+
+#import <Availability.h>
+
+#if defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
+#import <UIKit/UIKit.h>
+
+/**
+ `HatenaAFNetworkActivityIndicatorManager` manages the state of the network activity indicator in the status bar. When enabled, it will listen for notifications indicating that a network request operation has started or finished, and start or stop animating the indicator accordingly. The number of active requests is incremented and decremented much like a stack or a semaphore, and the activity indicator will animate so long as that number is greater than zero.
+
+ You should enable the shared instance of `HatenaAFNetworkActivityIndicatorManager` when your application finishes launching. In `AppDelegate application:didFinishLaunchingWithOptions:` you can do so with the following code:
+
+    [[HatenaAFNetworkActivityIndicatorManager sharedManager] setEnabled:YES];
+
+ By setting `isNetworkActivityIndicatorVisible` to `YES` for `sharedManager`, the network activity indicator will show and hide automatically as requests start and finish. You should not ever need to call `incrementActivityCount` or `decrementActivityCount` yourself.
+
+ See the Apple Human Interface Guidelines section about the Network Activity Indicator for more information:
+ http://developer.apple.com/library/iOS/#documentation/UserExperience/Conceptual/MobileHIG/UIElementGuidelines/UIElementGuidelines.html#//apple_ref/doc/uid/TP40006556-CH13-SW44
+ */
+@interface HatenaAFNetworkActivityIndicatorManager : NSObject
+
+/**
+ A Boolean value indicating whether the manager is enabled.
+
+ If YES, the manager will change status bar network activity indicator according to network operation notifications it receives. The default value is NO.
+ */
+@property (nonatomic, assign, getter = isEnabled) BOOL enabled;
+
+/**
+ A Boolean value indicating whether the network activity indicator is currently displayed in the status bar.
+ */
+@property (readonly, nonatomic, assign) BOOL isNetworkActivityIndicatorVisible;
+
+/**
+ Returns the shared network activity indicator manager object for the system.
+
+ @return The systemwide network activity indicator manager.
+ */
++ (instancetype)sharedManager;
+
+/**
+ Increments the number of active network requests. If this number was zero before incrementing, this will start animating the status bar network activity indicator.
+ */
+- (void)incrementActivityCount;
+
+/**
+ Decrements the number of active network requests. If this number becomes zero before decrementing, this will stop animating the status bar network activity indicator.
+ */
+- (void)decrementActivityCount;
+
+@end
+
+#endif

--- a/SDK/API/AFNetworking/HatenaAFNetworkActivityIndicatorManager.m
+++ b/SDK/API/AFNetworking/HatenaAFNetworkActivityIndicatorManager.m
@@ -1,0 +1,157 @@
+// HatenaAFNetworkActivityIndicatorManager.m
+//
+// Copyright (c) 2011 Gowalla (http://gowalla.com/)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "HatenaAFNetworkActivityIndicatorManager.h"
+
+#import "HatenaAFHTTPRequestOperation.h"
+
+#if defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
+static NSTimeInterval const kHatenaAFNetworkActivityIndicatorInvisibilityDelay = 0.17;
+
+@interface HatenaAFNetworkActivityIndicatorManager ()
+@property (readwrite, nonatomic, assign) NSInteger activityCount;
+@property (readwrite, nonatomic, strong) NSTimer *activityIndicatorVisibilityTimer;
+@property (readonly, nonatomic, getter = isNetworkActivityIndicatorVisible) BOOL networkActivityIndicatorVisible;
+
+- (void)updateNetworkActivityIndicatorVisibility;
+- (void)updateNetworkActivityIndicatorVisibilityDelayed;
+@end
+
+@implementation HatenaAFNetworkActivityIndicatorManager
+@synthesize activityCount = _activityCount;
+@synthesize activityIndicatorVisibilityTimer = _activityIndicatorVisibilityTimer;
+@synthesize enabled = _enabled;
+@dynamic networkActivityIndicatorVisible;
+
++ (instancetype)sharedManager {
+    static HatenaAFNetworkActivityIndicatorManager *_sharedManager = nil;
+    static dispatch_once_t oncePredicate;
+    dispatch_once(&oncePredicate, ^{
+        _sharedManager = [[self alloc] init];
+    });
+
+    return _sharedManager;
+}
+
++ (NSSet *)keyPathsForValuesAffectingIsNetworkActivityIndicatorVisible {
+    return [NSSet setWithObject:@"activityCount"];
+}
+
+- (id)init {
+    self = [super init];
+    if (!self) {
+        return nil;
+    }
+
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(networkingOperationDidStart:) name:HatenaAFNetworkingOperationDidStartNotification object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(networkingOperationDidFinish:) name:HatenaAFNetworkingOperationDidFinishNotification object:nil];
+
+    return self;
+}
+
+- (void)dealloc {
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+
+    [_activityIndicatorVisibilityTimer invalidate];
+
+}
+
+- (void)updateNetworkActivityIndicatorVisibilityDelayed {
+    if (self.enabled) {
+        // Delay hiding of activity indicator for a short interval, to avoid flickering
+        if (![self isNetworkActivityIndicatorVisible]) {
+            [self.activityIndicatorVisibilityTimer invalidate];
+            self.activityIndicatorVisibilityTimer = [NSTimer timerWithTimeInterval:kHatenaAFNetworkActivityIndicatorInvisibilityDelay target:self selector:@selector(updateNetworkActivityIndicatorVisibility) userInfo:nil repeats:NO];
+            [[NSRunLoop mainRunLoop] addTimer:self.activityIndicatorVisibilityTimer forMode:NSRunLoopCommonModes];
+        } else {
+            [self performSelectorOnMainThread:@selector(updateNetworkActivityIndicatorVisibility) withObject:nil waitUntilDone:NO modes:[NSArray arrayWithObject:NSRunLoopCommonModes]];
+        }
+    }
+}
+
+- (BOOL)isNetworkActivityIndicatorVisible {
+    return _activityCount > 0;
+}
+
+- (void)updateNetworkActivityIndicatorVisibility {
+    [[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:[self isNetworkActivityIndicatorVisible]];
+}
+
+// Not exposed, but used if activityCount is set via KVC.
+- (NSInteger)activityCount {
+	return _activityCount;
+}
+
+- (void)setActivityCount:(NSInteger)activityCount {
+	@synchronized(self) {
+		_activityCount = activityCount;
+	}
+    
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self updateNetworkActivityIndicatorVisibilityDelayed];
+    });
+}
+
+- (void)incrementActivityCount {
+    [self willChangeValueForKey:@"activityCount"];
+	@synchronized(self) {
+		_activityCount++;
+	}
+    [self didChangeValueForKey:@"activityCount"];
+    
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self updateNetworkActivityIndicatorVisibilityDelayed];
+    });
+}
+
+- (void)decrementActivityCount {
+    [self willChangeValueForKey:@"activityCount"];
+	@synchronized(self) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wgnu"
+		_activityCount = MAX(_activityCount - 1, 0);
+#pragma clang diagnostic pop
+	}
+    [self didChangeValueForKey:@"activityCount"];
+    
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self updateNetworkActivityIndicatorVisibilityDelayed];
+    });
+}
+
+- (void)networkingOperationDidStart:(NSNotification *)notification {
+    HatenaAFURLConnectionOperation *connectionOperation = [notification object];
+    if (connectionOperation.request.URL) {
+        [self incrementActivityCount];
+    }
+}
+
+- (void)networkingOperationDidFinish:(NSNotification *)notification {
+    HatenaAFURLConnectionOperation *connectionOperation = [notification object];
+    if (connectionOperation.request.URL) {
+        [self decrementActivityCount];
+    }
+}
+
+@end
+
+#endif

--- a/SDK/API/AFNetworking/HatenaAFNetworking.h
+++ b/SDK/API/AFNetworking/HatenaAFNetworking.h
@@ -1,0 +1,43 @@
+// HatenaAFNetworking.h
+//
+// Copyright (c) 2011 Gowalla (http://gowalla.com/)
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <Foundation/Foundation.h>
+#import <Availability.h>
+
+#ifndef _HatenaAFNETWORKING_
+    #define _HatenaAFNETWORKING_
+
+    #import "HatenaAFURLConnectionOperation.h"
+
+    #import "HatenaAFHTTPRequestOperation.h"
+    #import "HatenaAFJSONRequestOperation.h"
+    #import "HatenaAFXMLRequestOperation.h"
+    #import "HatenaAFPropertyListRequestOperation.h"
+    #import "HatenaAFHTTPClient.h"
+
+    #import "HatenaAFImageRequestOperation.h"
+
+    #if defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
+        #import "HatenaAFNetworkActivityIndicatorManager.h"
+        #import "UIImageView+HatenaAFNetworking.h"
+    #endif
+#endif /* _HatenaAFNETWORKING_ */

--- a/SDK/API/AFNetworking/HatenaAFPropertyListRequestOperation.h
+++ b/SDK/API/AFNetworking/HatenaAFPropertyListRequestOperation.h
@@ -1,0 +1,68 @@
+// HatenaAFPropertyListRequestOperation.h
+//
+// Copyright (c) 2011 Gowalla (http://gowalla.com/)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <Foundation/Foundation.h>
+#import "HatenaAFHTTPRequestOperation.h"
+
+/**
+ `HatenaAFPropertyListRequestOperation` is a subclass of `HatenaAFHTTPRequestOperation` for downloading and deserializing objects with property list (plist) response data.
+
+ ## Acceptable Content Types
+
+ By default, `HatenaAFPropertyListRequestOperation` accepts the following MIME types:
+
+ - `application/x-plist`
+ */
+@interface HatenaAFPropertyListRequestOperation : HatenaAFHTTPRequestOperation
+
+///----------------------------
+/// @name Getting Response Data
+///----------------------------
+
+/**
+ An object deserialized from a plist constructed using the response data.
+ */
+@property (readonly, nonatomic) id responsePropertyList;
+
+///--------------------------------------
+/// @name Managing Property List Behavior
+///--------------------------------------
+
+/**
+ One of the `NSPropertyListMutabilityOptions` options, specifying the mutability of objects deserialized from the property list. By default, this is `NSPropertyListImmutable`.
+ */
+@property (nonatomic, assign) NSPropertyListReadOptions propertyListReadOptions;
+
+/**
+ Creates and returns an `HatenaAFPropertyListRequestOperation` object and sets the specified success and failure callbacks.
+
+ @param urlRequest The request object to be loaded asynchronously during execution of the operation
+ @param success A block object to be executed when the operation finishes successfully. This block has no return value and takes three arguments: the request sent from the client, the response received from the server, and the object deserialized from a plist constructed using the response data.
+ @param failure A block object to be executed when the operation finishes unsuccessfully, or that finishes successfully, but encountered an error while deserializing the object from a property list. This block has no return value and takes three arguments: the request sent from the client, the response received from the server, and the error describing the network or parsing error that occurred.
+
+ @return A new property list request operation
+ */
++ (instancetype)propertyListRequestOperationWithRequest:(NSURLRequest *)urlRequest
+												success:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, id propertyList))success
+												failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error, id propertyList))failure;
+
+@end

--- a/SDK/API/AFNetworking/HatenaAFPropertyListRequestOperation.m
+++ b/SDK/API/AFNetworking/HatenaAFPropertyListRequestOperation.m
@@ -1,0 +1,143 @@
+// HatenaAFPropertyListRequestOperation.m
+//
+// Copyright (c) 2011 Gowalla (http://gowalla.com/)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "HatenaAFPropertyListRequestOperation.h"
+
+static dispatch_queue_t property_list_request_operation_processing_queue() {
+    static dispatch_queue_t af_property_list_request_operation_processing_queue;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        af_property_list_request_operation_processing_queue = dispatch_queue_create("com.alamofire.networking.property-list-request.processing", DISPATCH_QUEUE_CONCURRENT);
+    });
+
+    return af_property_list_request_operation_processing_queue;
+}
+
+@interface HatenaAFPropertyListRequestOperation ()
+@property (readwrite, nonatomic) id responsePropertyList;
+@property (readwrite, nonatomic, assign) NSPropertyListFormat propertyListFormat;
+@property (readwrite, nonatomic) NSError *propertyListError;
+@end
+
+@implementation HatenaAFPropertyListRequestOperation
+@synthesize responsePropertyList = _responsePropertyList;
+@synthesize propertyListReadOptions = _propertyListReadOptions;
+@synthesize propertyListFormat = _propertyListFormat;
+@synthesize propertyListError = _propertyListError;
+
++ (instancetype)propertyListRequestOperationWithRequest:(NSURLRequest *)request
+												success:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, id propertyList))success
+												failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error, id propertyList))failure
+{
+    HatenaAFPropertyListRequestOperation *requestOperation = [(HatenaAFPropertyListRequestOperation *)[self alloc] initWithRequest:request];
+    [requestOperation setCompletionBlockWithSuccess:^(HatenaAFHTTPRequestOperation *operation, id responseObject) {
+        if (success) {
+            success(operation.request, operation.response, responseObject);
+        }
+    } failure:^(HatenaAFHTTPRequestOperation *operation, NSError *error) {
+        if (failure) {
+            failure(operation.request, operation.response, error, [(HatenaAFPropertyListRequestOperation *)operation responsePropertyList]);
+        }
+    }];
+
+    return requestOperation;
+}
+
+- (id)initWithRequest:(NSURLRequest *)urlRequest {
+    self = [super initWithRequest:urlRequest];
+    if (!self) {
+        return nil;
+    }
+
+    self.propertyListReadOptions = NSPropertyListImmutable;
+
+    return self;
+}
+
+
+- (id)responsePropertyList {
+    if (!_responsePropertyList && [self.responseData length] > 0 && [self isFinished]) {
+        NSPropertyListFormat format;
+        NSError *error = nil;
+        self.responsePropertyList = [NSPropertyListSerialization propertyListWithData:self.responseData options:self.propertyListReadOptions format:&format error:&error];
+        self.propertyListFormat = format;
+        self.propertyListError = error;
+    }
+
+    return _responsePropertyList;
+}
+
+- (NSError *)error {
+    if (_propertyListError) {
+        return _propertyListError;
+    } else {
+        return [super error];
+    }
+}
+
+#pragma mark - HatenaAFHTTPRequestOperation
+
++ (NSSet *)acceptableContentTypes {
+    return [NSSet setWithObjects:@"application/x-plist", nil];
+}
+
++ (BOOL)canProcessRequest:(NSURLRequest *)request {
+    return [[[request URL] pathExtension] isEqualToString:@"plist"] || [super canProcessRequest:request];
+}
+
+- (void)setCompletionBlockWithSuccess:(void (^)(HatenaAFHTTPRequestOperation *operation, id responseObject))success
+                              failure:(void (^)(HatenaAFHTTPRequestOperation *operation, NSError *error))failure
+{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-retain-cycles"
+#pragma clang diagnostic ignored "-Wgnu"
+    self.completionBlock = ^ {
+        if (self.error) {
+            if (failure) {
+                dispatch_async(self.failureCallbackQueue ?: dispatch_get_main_queue(), ^{
+                    failure(self, self.error);
+                });
+            }
+        } else {
+            dispatch_async(property_list_request_operation_processing_queue(), ^(void) {
+                id propertyList = self.responsePropertyList;
+
+                if (self.propertyListError) {
+                    if (failure) {
+                        dispatch_async(self.failureCallbackQueue ?: dispatch_get_main_queue(), ^{
+                            failure(self, self.error);
+                        });
+                    }
+                } else {
+                    if (success) {
+                        dispatch_async(self.successCallbackQueue ?: dispatch_get_main_queue(), ^{
+                            success(self, propertyList);
+                        });
+                    }
+                }
+            });
+        }
+    };
+#pragma clang diagnostic pop
+}
+
+@end

--- a/SDK/API/AFNetworking/HatenaAFURLConnectionOperation.h
+++ b/SDK/API/AFNetworking/HatenaAFURLConnectionOperation.h
@@ -1,0 +1,370 @@
+// HatenaAFURLConnectionOperation.h
+//
+// Copyright (c) 2011 Gowalla (http://gowalla.com/)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <Foundation/Foundation.h>
+
+#import <Availability.h>
+
+/**
+ `HatenaAFURLConnectionOperation` is a subclass of `NSOperation` that implements `NSURLConnection` delegate methods.
+
+ ## Subclassing Notes
+
+ This is the base class of all network request operations. You may wish to create your own subclass in order to implement additional `NSURLConnection` delegate methods (see "`NSURLConnection` Delegate Methods" below), or to provide additional properties and/or class constructors.
+
+ If you are creating a subclass that communicates over the HTTP or HTTPS protocols, you may want to consider subclassing `HatenaAFHTTPRequestOperation` instead, as it supports specifying acceptable content types or status codes.
+
+ ## NSURLConnection Delegate Methods
+
+ `HatenaAFURLConnectionOperation` implements the following `NSURLConnection` delegate methods:
+
+ - `connection:didReceiveResponse:`
+ - `connection:didReceiveData:`
+ - `connectionDidFinishLoading:`
+ - `connection:didFailWithError:`
+ - `connection:didSendBodyData:totalBytesWritten:totalBytesExpectedToWrite:`
+ - `connection:willCacheResponse:`
+ - `connectionShouldUseCredentialStorage:`
+ - `connection:willSendRequestForAuthenticationChallenge:`
+
+ If any of these methods are overridden in a subclass, they _must_ call the `super` implementation first.
+
+ ## Class Constructors
+
+ Class constructors, or methods that return an unowned instance, are the preferred way for subclasses to encapsulate any particular logic for handling the setup or parsing of response data. For instance, `HatenaAFJSONRequestOperation` provides `JSONRequestOperationWithRequest:success:failure:`, which takes block arguments, whose parameter on for a successful request is the JSON object initialized from the `response data`.
+
+ ## Callbacks and Completion Blocks
+
+ The built-in `completionBlock` provided by `NSOperation` allows for custom behavior to be executed after the request finishes. It is a common pattern for class constructors in subclasses to take callback block parameters, and execute them conditionally in the body of its `completionBlock`. Make sure to handle cancelled operations appropriately when setting a `completionBlock` (i.e. returning early before parsing response data). See the implementation of any of the `HatenaAFHTTPRequestOperation` subclasses for an example of this.
+
+ Subclasses are strongly discouraged from overriding `setCompletionBlock:`, as `HatenaAFURLConnectionOperation`'s implementation includes a workaround to mitigate retain cycles, and what Apple rather ominously refers to as ["The Deallocation Problem"](http://developer.apple.com/library/ios/#technotes/tn2109/).
+ 
+ ## SSL Pinning
+ 
+ Relying on the CA trust model to validate SSL certificates exposes your app to security vulnerabilities, such as man-in-the-middle attacks. For applications that connect to known servers, SSL certificate pinning provides an increased level of security, by checking server certificate validity against those specified in the app bundle.
+ 
+ SSL with certificate pinning is strongly recommended for any application that transmits sensitive information to an external webservice.
+
+ When `defaultSSLPinningMode` is defined on `HatenaAFHTTPClient` and the Security framework is linked, connections will be validated on all matching certificates with a `.cer` extension in the bundle root.
+
+ ## NSCoding & NSCopying Conformance
+
+ `HatenaAFURLConnectionOperation` conforms to the `NSCoding` and `NSCopying` protocols, allowing operations to be archived to disk, and copied in memory, respectively. However, because of the intrinsic limitations of capturing the exact state of an operation at a particular moment, there are some important caveats to keep in mind:
+
+ ### NSCoding Caveats
+
+ - Encoded operations do not include any block or stream properties. Be sure to set `completionBlock`, `outputStream`, and any callback blocks as necessary when using `-initWithCoder:` or `NSKeyedUnarchiver`.
+ - Operations are paused on `encodeWithCoder:`. If the operation was encoded while paused or still executing, its archived state will return `YES` for `isReady`. Otherwise, the state of an operation when encoding will remain unchanged.
+
+ ### NSCopying Caveats
+
+ - `-copy` and `-copyWithZone:` return a new operation with the `NSURLRequest` of the original. So rather than an exact copy of the operation at that particular instant, the copying mechanism returns a completely new instance, which can be useful for retrying operations.
+ - A copy of an operation will not include the `outputStream` of the original.
+ - Operation copies do not include `completionBlock`. `completionBlock` often strongly captures a reference to `self`, which would otherwise have the unintuitive side-effect of pointing to the _original_ operation when copied.
+ */
+
+typedef enum {
+    HatenaAFSSLPinningModeNone,
+    HatenaAFSSLPinningModePublicKey,
+    HatenaAFSSLPinningModeCertificate,
+} HatenaAFURLConnectionOperationSSLPinningMode;
+
+@interface HatenaAFURLConnectionOperation : NSOperation <NSURLConnectionDelegate,
+#if (defined(__IPHONE_OS_VERSION_MIN_REQUIRED) && __IPHONE_OS_VERSION_MIN_REQUIRED >= 50000) || \
+    (defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 1080)
+NSURLConnectionDataDelegate, 
+#endif
+NSCoding, NSCopying>
+
+///-------------------------------
+/// @name Accessing Run Loop Modes
+///-------------------------------
+
+/**
+ The run loop modes in which the operation will run on the network thread. By default, this is a single-member set containing `NSRunLoopCommonModes`.
+ */
+@property (nonatomic, strong) NSSet *runLoopModes;
+
+///-----------------------------------------
+/// @name Getting URL Connection Information
+///-----------------------------------------
+
+/**
+ The request used by the operation's connection.
+ */
+@property (readonly, nonatomic, strong) NSURLRequest *request;
+
+/**
+ The last response received by the operation's connection.
+ */
+@property (readonly, nonatomic, strong) NSURLResponse *response;
+
+/**
+ The error, if any, that occurred in the lifecycle of the request.
+ */
+@property (readonly, nonatomic, strong) NSError *error;
+
+/**
+ Whether the connection should accept an invalid SSL certificate.
+ 
+ If `_HatenaAFNETWORKING_ALLOW_INVALID_SSL_CERTIFICATES_` is set, this property defaults to `YES` for backwards compatibility. Otherwise, this property defaults to `NO`.
+ */
+@property (nonatomic, assign) BOOL allowsInvalidSSLCertificate;
+
+///----------------------------
+/// @name Getting Response Data
+///----------------------------
+
+/**
+ The data received during the request.
+ */
+@property (readonly, nonatomic, strong) NSData *responseData;
+
+/**
+ The string representation of the response data.
+ */
+@property (readonly, nonatomic, copy) NSString *responseString;
+
+/**
+ The string encoding of the response.
+
+ If the response does not specify a valid string encoding, `responseStringEncoding` will return `NSUTF8StringEncoding`.
+ */
+@property (readonly, nonatomic, assign) NSStringEncoding responseStringEncoding;
+
+///-------------------------------
+/// @name Managing URL Credentials
+///-------------------------------
+
+/**
+ Whether the URL connection should consult the credential storage for authenticating the connection. `YES` by default.
+
+ This is the value that is returned in the `NSURLConnectionDelegate` method `-connectionShouldUseCredentialStorage:`.
+ */
+@property (nonatomic, assign) BOOL shouldUseCredentialStorage;
+
+/**
+ The credential used for authentication challenges in `-connection:didReceiveAuthenticationChallenge:`.
+
+ This will be overridden by any shared credentials that exist for the username or password of the request URL, if present.
+ */
+@property (nonatomic, strong) NSURLCredential *credential;
+
+/**
+ The pinning mode which will be used for SSL connections. `HatenaAFSSLPinningModePublicKey` by default.
+ 
+ SSL Pinning requires that the Security framework is linked with the binary. See the "SSL Pinning" section in the `HatenaAFURLConnectionOperation`" header for more information.
+ */
+@property (nonatomic, assign) HatenaAFURLConnectionOperationSSLPinningMode SSLPinningMode;
+
+///------------------------
+/// @name Accessing Streams
+///------------------------
+
+/**
+ The input stream used to read data to be sent during the request.
+
+ This property acts as a proxy to the `HTTPBodyStream` property of `request`.
+ */
+@property (nonatomic, strong) NSInputStream *inputStream;
+
+/**
+ The output stream that is used to write data received until the request is finished.
+
+ By default, data is accumulated into a buffer that is stored into `responseData` upon completion of the request. When `outputStream` is set, the data will not be accumulated into an internal buffer, and as a result, the `responseData` property of the completed request will be `nil`. The output stream will be scheduled in the network thread runloop upon being set.
+ */
+@property (nonatomic, strong) NSOutputStream *outputStream;
+
+///---------------------------------------------
+/// @name Managing Request Operation Information
+///---------------------------------------------
+
+/**
+ The user info dictionary for the receiver.
+ */
+@property (nonatomic, strong) NSDictionary *userInfo;
+
+///------------------------------------------------------
+/// @name Initializing an HatenaAFURLConnectionOperation Object
+///------------------------------------------------------
+
+/**
+ Initializes and returns a newly allocated operation object with a url connection configured with the specified url request.
+ 
+ This is the designated initializer.
+ 
+ @param urlRequest The request object to be used by the operation connection.
+ */
+- (id)initWithRequest:(NSURLRequest *)urlRequest;
+
+///----------------------------------
+/// @name Pausing / Resuming Requests
+///----------------------------------
+
+/**
+ Pauses the execution of the request operation.
+
+ A paused operation returns `NO` for `-isReady`, `-isExecuting`, and `-isFinished`. As such, it will remain in an `NSOperationQueue` until it is either cancelled or resumed. Pausing a finished, cancelled, or paused operation has no effect.
+ */
+- (void)pause;
+
+/**
+ Whether the request operation is currently paused.
+
+ @return `YES` if the operation is currently paused, otherwise `NO`.
+ */
+- (BOOL)isPaused;
+
+/**
+ Resumes the execution of the paused request operation.
+
+ Pause/Resume behavior varies depending on the underlying implementation for the operation class. In its base implementation, resuming a paused requests restarts the original request. However, since HTTP defines a specification for how to request a specific content range, `HatenaAFHTTPRequestOperation` will resume downloading the request from where it left off, instead of restarting the original request.
+ */
+- (void)resume;
+
+///----------------------------------------------
+/// @name Configuring Backgrounding Task Behavior
+///----------------------------------------------
+
+/**
+ Specifies that the operation should continue execution after the app has entered the background, and the expiration handler for that background task.
+
+ @param handler A handler to be called shortly before the application’s remaining background time reaches 0. The handler is wrapped in a block that cancels the operation, and cleans up and marks the end of execution, unlike the `handler` parameter in `UIApplication -beginBackgroundTaskWithExpirationHandler:`, which expects this to be done in the handler itself. The handler is called synchronously on the main thread, thus blocking the application’s suspension momentarily while the application is notified.
+ */
+#if defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
+- (void)setShouldExecuteAsBackgroundTaskWithExpirationHandler:(void (^)(void))handler;
+#endif
+
+///---------------------------------
+/// @name Setting Progress Callbacks
+///---------------------------------
+
+/**
+ Sets a callback to be called when an undetermined number of bytes have been uploaded to the server.
+
+ @param block A block object to be called when an undetermined number of bytes have been uploaded to the server. This block has no return value and takes three arguments: the number of bytes written since the last time the upload progress block was called, the total bytes written, and the total bytes expected to be written during the request, as initially determined by the length of the HTTP body. This block may be called multiple times, and will execute on the main thread.
+ */
+- (void)setUploadProgressBlock:(void (^)(NSUInteger bytesWritten, long long totalBytesWritten, long long totalBytesExpectedToWrite))block;
+
+/**
+ Sets a callback to be called when an undetermined number of bytes have been downloaded from the server.
+
+ @param block A block object to be called when an undetermined number of bytes have been downloaded from the server. This block has no return value and takes three arguments: the number of bytes read since the last time the download progress block was called, the total bytes read, and the total bytes expected to be read during the request, as initially determined by the expected content size of the `NSHTTPURLResponse` object. This block may be called multiple times, and will execute on the main thread.
+ */
+- (void)setDownloadProgressBlock:(void (^)(NSUInteger bytesRead, long long totalBytesRead, long long totalBytesExpectedToRead))block;
+
+///-------------------------------------------------
+/// @name Setting NSURLConnection Delegate Callbacks
+///-------------------------------------------------
+
+/**
+ Sets a block to be executed when the connection will authenticate a challenge in order to download its request, as handled by the `NSURLConnectionDelegate` method `connection:willSendRequestForAuthenticationChallenge:`.
+ 
+ @param block A block object to be executed when the connection will authenticate a challenge in order to download its request. The block has no return type and takes two arguments: the URL connection object, and the challenge that must be authenticated. This block must invoke one of the challenge-responder methods (NSURLAuthenticationChallengeSender protocol).
+ 
+ If `allowsInvalidSSLCertificate` is set to YES, `connection:willSendRequestForAuthenticationChallenge:` will attempt to have the challenge sender use credentials with invalid SSL certificates.
+ */
+- (void)setWillSendRequestForAuthenticationChallengeBlock:(void (^)(NSURLConnection *connection, NSURLAuthenticationChallenge *challenge))block;
+
+/**
+ Sets a block to be executed when the server redirects the request from one URL to another URL, or when the request URL changed by the `NSURLProtocol` subclass handling the request in order to standardize its format, as handled by the `NSURLConnectionDelegate` method `connection:willSendRequest:redirectResponse:`.
+
+ @param block A block object to be executed when the request URL was changed. The block returns an `NSURLRequest` object, the URL request to redirect, and takes three arguments: the URL connection object, the the proposed redirected request, and the URL response that caused the redirect.
+ */
+- (void)setRedirectResponseBlock:(NSURLRequest * (^)(NSURLConnection *connection, NSURLRequest *request, NSURLResponse *redirectResponse))block;
+
+/**
+ Sets a block to be executed to modify the response a connection will cache, if any, as handled by the `NSURLConnectionDelegate` method `connection:willCacheResponse:`.
+
+ @param block A block object to be executed to determine what response a connection will cache, if any. The block returns an `NSCachedURLResponse` object, the cached response to store in memory or `nil` to prevent the response from being cached, and takes two arguments: the URL connection object, and the cached response provided for the request.
+ */
+- (void)setCacheResponseBlock:(NSCachedURLResponse * (^)(NSURLConnection *connection, NSCachedURLResponse *cachedResponse))block;
+
+@end
+
+///----------------
+/// @name Constants
+///----------------
+
+/**
+ ## SSL Pinning Options
+
+ The following constants are provided by `HatenaAFURLConnectionOperation` as possible SSL Pinning options.
+
+ enum {
+ HatenaAFSSLPinningModeNone,
+ HatenaAFSSLPinningModePublicKey,
+ HatenaAFSSLPinningModeCertificate,
+ }
+ 
+ `HatenaAFSSLPinningModeNone`
+ Do not pin SSL connections
+
+ `HatenaAFSSLPinningModePublicKey`
+ Pin SSL connections to certificate public key (SPKI).
+
+ `HatenaAFSSLPinningModeCertificate`
+ Pin SSL connections to exact certificate. This may cause problems when your certificate expires and needs re-issuance.
+
+ ## User info dictionary keys
+
+ These keys may exist in the user info dictionary, in addition to those defined for NSError.
+
+ - `NSString * const HatenaAFNetworkingOperationFailingURLRequestErrorKey`
+ - `NSString * const HatenaAFNetworkingOperationFailingURLResponseErrorKey`
+
+ ### Constants
+
+ `HatenaAFNetworkingOperationFailingURLRequestErrorKey`
+ The corresponding value is an `NSURLRequest` containing the request of the operation associated with an error. This key is only present in the `HatenaAFNetworkingErrorDomain`.
+
+ `HatenaAFNetworkingOperationFailingURLResponseErrorKey`
+ The corresponding value is an `NSURLResponse` containing the response of the operation associated with an error. This key is only present in the `HatenaAFNetworkingErrorDomain`.
+
+ ## Error Domains
+
+ The following error domain is predefined.
+
+ - `NSString * const HatenaAFNetworkingErrorDomain`
+
+ ### Constants
+
+ `HatenaAFNetworkingErrorDomain`
+ HatenaAFNetworking errors. Error codes for `HatenaAFNetworkingErrorDomain` correspond to codes in `NSURLErrorDomain`.
+ */
+extern NSString * const HatenaAFNetworkingErrorDomain;
+extern NSString * const HatenaAFNetworkingOperationFailingURLRequestErrorKey;
+extern NSString * const HatenaAFNetworkingOperationFailingURLResponseErrorKey;
+
+///--------------------
+/// @name Notifications
+///--------------------
+
+/**
+ Posted when an operation begins executing.
+ */
+extern NSString * const HatenaAFNetworkingOperationDidStartNotification;
+
+/**
+ Posted when an operation finishes.
+ */
+extern NSString * const HatenaAFNetworkingOperationDidFinishNotification;

--- a/SDK/API/AFNetworking/HatenaAFURLConnectionOperation.m
+++ b/SDK/API/AFNetworking/HatenaAFURLConnectionOperation.m
@@ -1,0 +1,857 @@
+// HatenaAFURLConnectionOperation.m
+//
+// Copyright (c) 2011 Gowalla (http://gowalla.com/)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "HatenaAFURLConnectionOperation.h"
+
+#if defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
+#import <UIKit/UIKit.h>
+#endif
+
+#if !__has_feature(objc_arc)
+#error HatenaAFNetworking must be built with ARC.
+// You can turn on ARC for only HatenaAFNetworking files by adding -fobjc-arc to the build phase for each of its files.
+#endif
+
+typedef enum {
+    HatenaAFOperationPausedState      = -1,
+    HatenaAFOperationReadyState       = 1,
+    HatenaAFOperationExecutingState   = 2,
+    HatenaAFOperationFinishedState    = 3,
+} _HatenaAFOperationState;
+
+typedef signed short HatenaAFOperationState;
+
+#if defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
+typedef UIBackgroundTaskIdentifier HatenaAFBackgroundTaskIdentifier;
+#else
+typedef id HatenaAFBackgroundTaskIdentifier;
+#endif
+
+static NSString * const kHatenaAFNetworkingLockName = @"com.alamofire.networking.operation.lock";
+
+NSString * const HatenaAFNetworkingErrorDomain = @"HatenaAFNetworkingErrorDomain";
+NSString * const HatenaAFNetworkingOperationFailingURLRequestErrorKey = @"HatenaAFNetworkingOperationFailingURLRequestErrorKey";
+NSString * const HatenaAFNetworkingOperationFailingURLResponseErrorKey = @"HatenaAFNetworkingOperationFailingURLResponseErrorKey";
+
+NSString * const HatenaAFNetworkingOperationDidStartNotification = @"com.alamofire.networking.operation.start";
+NSString * const HatenaAFNetworkingOperationDidFinishNotification = @"com.alamofire.networking.operation.finish";
+
+typedef void (^HatenaAFURLConnectionOperationProgressBlock)(NSUInteger bytes, long long totalBytes, long long totalBytesExpected);
+typedef void (^HatenaAFURLConnectionOperationAuthenticationChallengeBlock)(NSURLConnection *connection, NSURLAuthenticationChallenge *challenge);
+typedef NSCachedURLResponse * (^HatenaAFURLConnectionOperationCacheResponseBlock)(NSURLConnection *connection, NSCachedURLResponse *cachedResponse);
+typedef NSURLRequest * (^HatenaAFURLConnectionOperationRedirectResponseBlock)(NSURLConnection *connection, NSURLRequest *request, NSURLResponse *redirectResponse);
+
+static inline NSString * HatenaAFKeyPathFromOperationState(HatenaAFOperationState state) {
+    switch (state) {
+        case HatenaAFOperationReadyState:
+            return @"isReady";
+        case HatenaAFOperationExecutingState:
+            return @"isExecuting";
+        case HatenaAFOperationFinishedState:
+            return @"isFinished";
+        case HatenaAFOperationPausedState:
+            return @"isPaused";
+        default:
+            return @"state";
+    }
+}
+
+static inline BOOL HatenaAFStateTransitionIsValid(HatenaAFOperationState fromState, HatenaAFOperationState toState, BOOL isCancelled) {
+    switch (fromState) {
+        case HatenaAFOperationReadyState:
+            switch (toState) {
+                case HatenaAFOperationPausedState:
+                case HatenaAFOperationExecutingState:
+                    return YES;
+                case HatenaAFOperationFinishedState:
+                    return isCancelled;
+                default:
+                    return NO;
+            }
+        case HatenaAFOperationExecutingState:
+            switch (toState) {
+                case HatenaAFOperationPausedState:
+                case HatenaAFOperationFinishedState:
+                    return YES;
+                default:
+                    return NO;
+            }
+        case HatenaAFOperationFinishedState:
+            return NO;
+        case HatenaAFOperationPausedState:
+            return toState == HatenaAFOperationReadyState;
+        default:
+            return YES;
+    }
+}
+
+#if !defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
+static NSData *HatenaAFSecKeyGetData(SecKeyRef key) {
+    CFDataRef data = NULL;
+    
+#if defined(NS_BLOCK_ASSERTIONS)
+    SecItemExport(key, kSecFormatUnknown, kSecItemPemArmour, NULL, &data);
+#else
+    OSStatus status = SecItemExport(key, kSecFormatUnknown, kSecItemPemArmour, NULL, &data);
+    NSCAssert(status == errSecSuccess, @"SecItemExport error: %ld", (long int)status);
+#endif
+
+    NSCParameterAssert(data);
+    
+    return (__bridge_transfer NSData *)data;
+}
+#endif
+
+static BOOL HatenaAFSecKeyIsEqualToKey(SecKeyRef key1, SecKeyRef key2) {
+#if defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
+    return [(__bridge id)key1 isEqual:(__bridge id)key2];
+#else
+    return [HatenaAFSecKeyGetData(key1) isEqual:HatenaAFSecKeyGetData(key2)];
+#endif
+}
+
+@interface HatenaAFURLConnectionOperation ()
+@property (readwrite, nonatomic, assign) HatenaAFOperationState state;
+@property (readwrite, nonatomic, assign, getter = isCancelled) BOOL cancelled;
+@property (readwrite, nonatomic, strong) NSRecursiveLock *lock;
+@property (readwrite, nonatomic, strong) NSURLConnection *connection;
+@property (readwrite, nonatomic, strong) NSURLRequest *request;
+@property (readwrite, nonatomic, strong) NSURLResponse *response;
+@property (readwrite, nonatomic, strong) NSError *error;
+@property (readwrite, nonatomic, strong) NSData *responseData;
+@property (readwrite, nonatomic, copy) NSString *responseString;
+@property (readwrite, nonatomic, assign) NSStringEncoding responseStringEncoding;
+@property (readwrite, nonatomic, assign) long long totalBytesRead;
+@property (readwrite, nonatomic, assign) HatenaAFBackgroundTaskIdentifier backgroundTaskIdentifier;
+@property (readwrite, nonatomic, copy) HatenaAFURLConnectionOperationProgressBlock uploadProgress;
+@property (readwrite, nonatomic, copy) HatenaAFURLConnectionOperationProgressBlock downloadProgress;
+@property (readwrite, nonatomic, copy) HatenaAFURLConnectionOperationAuthenticationChallengeBlock authenticationChallenge;
+@property (readwrite, nonatomic, copy) HatenaAFURLConnectionOperationCacheResponseBlock cacheResponse;
+@property (readwrite, nonatomic, copy) HatenaAFURLConnectionOperationRedirectResponseBlock redirectResponse;
+
+- (void)operationDidStart;
+- (void)finish;
+- (void)cancelConnection;
+@end
+
+@implementation HatenaAFURLConnectionOperation
+@synthesize state = _state;
+@synthesize cancelled = _cancelled;
+@synthesize connection = _connection;
+@synthesize runLoopModes = _runLoopModes;
+@synthesize request = _request;
+@synthesize response = _response;
+@synthesize error = _error;
+@synthesize allowsInvalidSSLCertificate = _allowsInvalidSSLCertificate;
+@synthesize responseData = _responseData;
+@synthesize responseString = _responseString;
+@synthesize responseStringEncoding = _responseStringEncoding;
+@synthesize totalBytesRead = _totalBytesRead;
+@dynamic inputStream;
+@synthesize outputStream = _outputStream;
+@synthesize credential = _credential;
+@synthesize SSLPinningMode = _SSLPinningMode;
+@synthesize shouldUseCredentialStorage = _shouldUseCredentialStorage;
+@synthesize userInfo = _userInfo;
+@synthesize backgroundTaskIdentifier = _backgroundTaskIdentifier;
+@synthesize uploadProgress = _uploadProgress;
+@synthesize downloadProgress = _downloadProgress;
+@synthesize authenticationChallenge = _authenticationChallenge;
+@synthesize cacheResponse = _cacheResponse;
+@synthesize redirectResponse = _redirectResponse;
+@synthesize lock = _lock;
+
++ (void)networkRequestThreadEntryPoint:(id __unused)object {
+    @autoreleasepool {
+        [[NSThread currentThread] setName:@"HatenaAFNetworking"];
+
+        NSRunLoop *runLoop = [NSRunLoop currentRunLoop];
+        [runLoop addPort:[NSMachPort port] forMode:NSDefaultRunLoopMode];
+        [runLoop run];
+    }
+}
+
++ (NSThread *)networkRequestThread {
+    static NSThread *_networkRequestThread = nil;
+    static dispatch_once_t oncePredicate;
+    dispatch_once(&oncePredicate, ^{
+        _networkRequestThread = [[NSThread alloc] initWithTarget:self selector:@selector(networkRequestThreadEntryPoint:) object:nil];
+        [_networkRequestThread start];
+    });
+    
+    return _networkRequestThread;
+}
+
++ (NSArray *)pinnedCertificates {
+    static NSArray *_pinnedCertificates = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        NSBundle *bundle = [NSBundle mainBundle];
+        NSArray *paths = [bundle pathsForResourcesOfType:@"cer" inDirectory:@"."];
+        
+        NSMutableArray *certificates = [NSMutableArray arrayWithCapacity:[paths count]];
+        for (NSString *path in paths) {
+            NSData *certificateData = [NSData dataWithContentsOfFile:path];
+            [certificates addObject:certificateData];
+        }
+        
+        _pinnedCertificates = [[NSArray alloc] initWithArray:certificates];
+    });
+    
+    return _pinnedCertificates;
+}
+
++ (NSArray *)pinnedPublicKeys {
+    static NSArray *_pinnedPublicKeys = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        NSArray *pinnedCertificates = [self pinnedCertificates];
+        NSMutableArray *publicKeys = [NSMutableArray arrayWithCapacity:[pinnedCertificates count]];
+        
+        for (NSData *data in pinnedCertificates) {
+            SecCertificateRef allowedCertificate = SecCertificateCreateWithData(NULL, (__bridge CFDataRef)data);
+            NSParameterAssert(allowedCertificate);
+            
+            SecCertificateRef allowedCertificates[] = {allowedCertificate};
+            CFArrayRef certificates = CFArrayCreate(NULL, (const void **)allowedCertificates, 1, NULL);
+            
+            SecPolicyRef policy = SecPolicyCreateBasicX509();
+            SecTrustRef allowedTrust = NULL;
+            OSStatus status = SecTrustCreateWithCertificates(certificates, policy, &allowedTrust);
+            NSAssert(status == errSecSuccess, @"SecTrustCreateWithCertificates error: %ld", (long int)status);
+            if (status == errSecSuccess && allowedTrust) {
+                SecTrustResultType result = 0;
+                status = SecTrustEvaluate(allowedTrust, &result);
+                NSAssert(status == errSecSuccess, @"SecTrustEvaluate error: %ld", (long int)status);
+                if (status == errSecSuccess) {
+                    SecKeyRef allowedPublicKey = SecTrustCopyPublicKey(allowedTrust);
+                    NSParameterAssert(allowedPublicKey);
+                    if (allowedPublicKey) {
+                        [publicKeys addObject:(__bridge_transfer id)allowedPublicKey];
+                    }
+                }
+                
+                CFRelease(allowedTrust);
+            }          
+            
+            CFRelease(policy);
+            CFRelease(certificates);
+            CFRelease(allowedCertificate);
+        }
+        
+        _pinnedPublicKeys = [[NSArray alloc] initWithArray:publicKeys];
+    });
+    
+    return _pinnedPublicKeys;
+}
+
+- (id)initWithRequest:(NSURLRequest *)urlRequest {
+    NSParameterAssert(urlRequest);
+
+    self = [super init];
+    if (!self) {
+		return nil;
+    }
+    
+    self.lock = [[NSRecursiveLock alloc] init];
+    self.lock.name = kHatenaAFNetworkingLockName;
+    
+    self.runLoopModes = [NSSet setWithObject:NSRunLoopCommonModes];
+    
+    self.request = urlRequest;
+    
+    self.shouldUseCredentialStorage = YES;
+
+    // #ifdef included for backwards-compatibility 
+#ifdef _HatenaAFNETWORKING_ALLOW_INVALID_SSL_CERTIFICATES_
+    self.allowsInvalidSSLCertificate = YES;
+#endif
+
+    self.state = HatenaAFOperationReadyState;
+
+    return self;
+}
+
+- (void)dealloc {
+    if (_outputStream) {
+        [_outputStream close];
+        _outputStream = nil;
+    }
+    
+#if defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
+    if (_backgroundTaskIdentifier) {
+        [[UIApplication sharedApplication] endBackgroundTask:_backgroundTaskIdentifier];
+        _backgroundTaskIdentifier = UIBackgroundTaskInvalid;
+    }
+#endif
+}
+
+- (NSString *)description {
+    return [NSString stringWithFormat:@"<%@: %p, state: %@, cancelled: %@ request: %@, response: %@>", NSStringFromClass([self class]), self, HatenaAFKeyPathFromOperationState(self.state), ([self isCancelled] ? @"YES" : @"NO"), self.request, self.response];
+}
+
+- (void)setCompletionBlock:(void (^)(void))block {
+    [self.lock lock];
+    if (!block) {
+        [super setCompletionBlock:nil];
+    } else {
+        __weak __typeof(&*self)weakSelf = self;
+        [super setCompletionBlock:^ {
+            __strong __typeof(&*weakSelf)strongSelf = weakSelf;
+            
+            block();
+            [strongSelf setCompletionBlock:nil];
+        }];
+    }
+    [self.lock unlock];
+}
+
+- (NSInputStream *)inputStream {
+    return self.request.HTTPBodyStream;
+}
+
+- (void)setInputStream:(NSInputStream *)inputStream {
+    [self willChangeValueForKey:@"inputStream"];
+    NSMutableURLRequest *mutableRequest = [self.request mutableCopy];
+    mutableRequest.HTTPBodyStream = inputStream;
+    self.request = mutableRequest;
+    [self didChangeValueForKey:@"inputStream"];
+}
+
+- (NSOutputStream *)outputStream {
+    if (!_outputStream) {
+        self.outputStream = [NSOutputStream outputStreamToMemory];
+    }
+
+    return _outputStream;
+}
+
+- (void)setOutputStream:(NSOutputStream *)outputStream {
+    [self.lock lock];
+    if (outputStream != _outputStream) {
+        [self willChangeValueForKey:@"outputStream"];
+        if (_outputStream) {
+            [_outputStream close];
+        }
+        _outputStream = outputStream;
+        [self didChangeValueForKey:@"outputStream"];
+    }
+    [self.lock unlock];
+}
+
+#if defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
+- (void)setShouldExecuteAsBackgroundTaskWithExpirationHandler:(void (^)(void))handler {
+    [self.lock lock];
+    if (!self.backgroundTaskIdentifier) {
+        UIApplication *application = [UIApplication sharedApplication];
+        __weak __typeof(&*self)weakSelf = self;
+        self.backgroundTaskIdentifier = [application beginBackgroundTaskWithExpirationHandler:^{
+            __strong __typeof(&*weakSelf)strongSelf = weakSelf;
+            
+            if (handler) {
+                handler();
+            }
+            
+            if (strongSelf) {
+                [strongSelf cancel];
+                
+                [application endBackgroundTask:strongSelf.backgroundTaskIdentifier];
+                strongSelf.backgroundTaskIdentifier = UIBackgroundTaskInvalid;
+            }
+        }];
+    }
+    [self.lock unlock];
+}
+#endif
+
+- (void)setUploadProgressBlock:(void (^)(NSUInteger bytesWritten, long long totalBytesWritten, long long totalBytesExpectedToWrite))block {
+    self.uploadProgress = block;
+}
+
+- (void)setDownloadProgressBlock:(void (^)(NSUInteger bytesRead, long long totalBytesRead, long long totalBytesExpectedToRead))block {
+    self.downloadProgress = block;
+}
+
+- (void)setWillSendRequestForAuthenticationChallengeBlock:(void (^)(NSURLConnection *connection, NSURLAuthenticationChallenge *challenge))block {
+    self.authenticationChallenge = block;
+}
+
+- (void)setCacheResponseBlock:(NSCachedURLResponse * (^)(NSURLConnection *connection, NSCachedURLResponse *cachedResponse))block {
+    self.cacheResponse = block;
+}
+
+- (void)setRedirectResponseBlock:(NSURLRequest * (^)(NSURLConnection *connection, NSURLRequest *request, NSURLResponse *redirectResponse))block {
+    self.redirectResponse = block;
+}
+
+- (void)setState:(HatenaAFOperationState)state {
+    if (!HatenaAFStateTransitionIsValid(self.state, state, [self isCancelled])) {
+        return;
+    }
+    
+    [self.lock lock];
+    NSString *oldStateKey = HatenaAFKeyPathFromOperationState(self.state);
+    NSString *newStateKey = HatenaAFKeyPathFromOperationState(state);
+    
+    [self willChangeValueForKey:newStateKey];
+    [self willChangeValueForKey:oldStateKey];
+    _state = state;
+    [self didChangeValueForKey:oldStateKey];
+    [self didChangeValueForKey:newStateKey];
+    [self.lock unlock];
+}
+
+- (NSString *)responseString {
+    [self.lock lock];
+    if (!_responseString && self.response && self.responseData) {
+        self.responseString = [[NSString alloc] initWithData:self.responseData encoding:self.responseStringEncoding];
+    }
+    [self.lock unlock];
+    
+    return _responseString;
+}
+
+- (NSStringEncoding)responseStringEncoding {
+    [self.lock lock];
+    if (!_responseStringEncoding && self.response) {
+        NSStringEncoding stringEncoding = NSUTF8StringEncoding;
+        if (self.response.textEncodingName) {
+            CFStringEncoding IANAEncoding = CFStringConvertIANACharSetNameToEncoding((__bridge CFStringRef)self.response.textEncodingName);
+            if (IANAEncoding != kCFStringEncodingInvalidId) {
+                stringEncoding = CFStringConvertEncodingToNSStringEncoding(IANAEncoding);
+            }
+        }
+        
+        self.responseStringEncoding = stringEncoding;
+    }
+    [self.lock unlock];
+    
+    return _responseStringEncoding;
+}
+
+- (void)pause {
+    if ([self isPaused] || [self isFinished] || [self isCancelled]) {
+        return;
+    }
+    
+    [self.lock lock];
+    
+    if ([self isExecuting]) {
+        [self.connection performSelector:@selector(cancel) onThread:[[self class] networkRequestThread] withObject:nil waitUntilDone:NO modes:[self.runLoopModes allObjects]];
+        
+        dispatch_async(dispatch_get_main_queue(), ^{
+            NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
+            [notificationCenter postNotificationName:HatenaAFNetworkingOperationDidFinishNotification object:self];
+        });
+    }
+    
+    self.state = HatenaAFOperationPausedState;
+    
+    [self.lock unlock];
+}
+
+- (BOOL)isPaused {
+    return self.state == HatenaAFOperationPausedState;
+}
+
+- (void)resume {
+    if (![self isPaused]) {
+        return;
+    }
+    
+    [self.lock lock];
+    self.state = HatenaAFOperationReadyState;
+    
+    [self start];
+    [self.lock unlock];
+}
+
+#pragma mark - NSOperation
+
+- (BOOL)isReady {
+    return self.state == HatenaAFOperationReadyState && [super isReady];
+}
+
+- (BOOL)isExecuting {
+    return self.state == HatenaAFOperationExecutingState;
+}
+
+- (BOOL)isFinished {
+    return self.state == HatenaAFOperationFinishedState;
+}
+
+- (BOOL)isConcurrent {
+    return YES;
+}
+
+- (void)start {
+    [self.lock lock];
+    if ([self isReady]) {
+        self.state = HatenaAFOperationExecutingState;
+        
+        [self performSelector:@selector(operationDidStart) onThread:[[self class] networkRequestThread] withObject:nil waitUntilDone:NO modes:[self.runLoopModes allObjects]];
+    }
+    [self.lock unlock];
+}
+
+- (void)operationDidStart {
+    [self.lock lock];
+    if (![self isCancelled]) {
+        self.connection = [[NSURLConnection alloc] initWithRequest:self.request delegate:self startImmediately:NO];
+        
+        NSRunLoop *runLoop = [NSRunLoop currentRunLoop];
+        for (NSString *runLoopMode in self.runLoopModes) {
+            [self.connection scheduleInRunLoop:runLoop forMode:runLoopMode];
+            [self.outputStream scheduleInRunLoop:runLoop forMode:runLoopMode];
+        }
+        
+        [self.connection start];
+    }
+    [self.lock unlock];
+    
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [[NSNotificationCenter defaultCenter] postNotificationName:HatenaAFNetworkingOperationDidStartNotification object:self];
+    });
+    
+    if ([self isCancelled]) {
+        NSDictionary *userInfo = nil;
+        if ([self.request URL]) {
+            userInfo = [NSDictionary dictionaryWithObject:[self.request URL] forKey:NSURLErrorFailingURLErrorKey];
+        }
+        self.error = [NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorCancelled userInfo:userInfo];
+
+        [self finish];
+    }
+}
+
+- (void)finish {
+    self.state = HatenaAFOperationFinishedState;
+    
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [[NSNotificationCenter defaultCenter] postNotificationName:HatenaAFNetworkingOperationDidFinishNotification object:self];
+    });
+}
+
+- (void)cancel {
+    [self.lock lock];
+    if (![self isFinished] && ![self isCancelled]) {
+        [self willChangeValueForKey:@"isCancelled"];
+        _cancelled = YES;
+        [super cancel];
+        [self didChangeValueForKey:@"isCancelled"];
+        
+        // Cancel the connection on the thread it runs on to prevent race conditions
+        [self performSelector:@selector(cancelConnection) onThread:[[self class] networkRequestThread] withObject:nil waitUntilDone:NO modes:[self.runLoopModes allObjects]];
+    }
+    [self.lock unlock];
+}
+
+- (void)cancelConnection {
+    NSDictionary *userInfo = nil;
+    if ([self.request URL]) {
+        userInfo = [NSDictionary dictionaryWithObject:[self.request URL] forKey:NSURLErrorFailingURLErrorKey];
+    }
+    NSError *error = [NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorCancelled userInfo:userInfo];
+    
+    if (![self isFinished] && self.connection) {
+        [self.connection cancel];
+        [self performSelector:@selector(connection:didFailWithError:) withObject:self.connection withObject:error];
+    }
+}
+
+#pragma mark - NSURLConnectionDelegate
+
+- (void)connection:(NSURLConnection *)connection
+willSendRequestForAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge
+{
+    if (self.authenticationChallenge) {
+        self.authenticationChallenge(connection, challenge);
+        return;
+    }
+    
+    if ([challenge.protectionSpace.authenticationMethod isEqualToString:NSURLAuthenticationMethodServerTrust]) {
+        SecTrustRef serverTrust = challenge.protectionSpace.serverTrust;
+        
+        SecPolicyRef policy = SecPolicyCreateBasicX509();
+        CFIndex certificateCount = SecTrustGetCertificateCount(serverTrust);
+        NSMutableArray *trustChain = [NSMutableArray arrayWithCapacity:certificateCount];
+        
+        for (CFIndex i = 0; i < certificateCount; i++) {
+            SecCertificateRef certificate = SecTrustGetCertificateAtIndex(serverTrust, i);
+            
+            if (self.SSLPinningMode == HatenaAFSSLPinningModeCertificate) {
+                [trustChain addObject:(__bridge_transfer NSData *)SecCertificateCopyData(certificate)];
+            } else if (self.SSLPinningMode == HatenaAFSSLPinningModePublicKey) {
+                SecCertificateRef someCertificates[] = {certificate};
+                CFArrayRef certificates = CFArrayCreate(NULL, (const void **)someCertificates, 1, NULL);
+                
+                SecTrustRef trust = NULL;
+                
+                OSStatus status = SecTrustCreateWithCertificates(certificates, policy, &trust);
+                NSAssert(status == errSecSuccess, @"SecTrustCreateWithCertificates error: %ld", (long int)status);
+                if (status == errSecSuccess && trust) {
+                    SecTrustResultType result;
+                    status = SecTrustEvaluate(trust, &result);
+                    NSAssert(status == errSecSuccess, @"SecTrustEvaluate error: %ld", (long int)status);
+                    if (status == errSecSuccess) {
+                        [trustChain addObject:(__bridge_transfer id)SecTrustCopyPublicKey(trust)];
+                    }
+
+                    CFRelease(trust);
+                }
+              
+                CFRelease(certificates);
+            }
+        }
+        
+        CFRelease(policy);
+        
+        switch (self.SSLPinningMode) {
+            case HatenaAFSSLPinningModePublicKey: {
+                NSArray *pinnedPublicKeys = [self.class pinnedPublicKeys];
+                NSAssert([pinnedPublicKeys count] > 0, @"HatenaAFSSLPinningModePublicKey needs at least one key file in the application bundle");
+
+                for (id publicKey in trustChain) {
+                    for (id pinnedPublicKey in pinnedPublicKeys) {
+                        if (HatenaAFSecKeyIsEqualToKey((__bridge SecKeyRef)publicKey, (__bridge SecKeyRef)pinnedPublicKey)) {
+                            NSURLCredential *credential = [NSURLCredential credentialForTrust:serverTrust];
+                            [[challenge sender] useCredential:credential forAuthenticationChallenge:challenge];
+                            return;
+                        }
+                    }
+                }
+                
+                NSLog(@"Error: Unknown Public Key during Pinning operation");
+                [[challenge sender] cancelAuthenticationChallenge:challenge];
+                break;
+            }
+            case HatenaAFSSLPinningModeCertificate: {
+                NSAssert([[self.class pinnedCertificates] count] > 0, @"HatenaAFSSLPinningModeCertificate needs at least one certificate file in the application bundle");
+                for (id serverCertificateData in trustChain) {
+                    if ([[self.class pinnedCertificates] containsObject:serverCertificateData]) {
+                        NSURLCredential *credential = [NSURLCredential credentialForTrust:serverTrust];
+                        [[challenge sender] useCredential:credential forAuthenticationChallenge:challenge];
+                        return;
+                    }
+                }
+                
+                NSLog(@"Error: Unknown Certificate during Pinning operation");
+                [[challenge sender] cancelAuthenticationChallenge:challenge];
+                break;
+            }
+            case HatenaAFSSLPinningModeNone: {
+                if (self.allowsInvalidSSLCertificate){
+                    NSURLCredential *credential = [NSURLCredential credentialForTrust:serverTrust];
+                    [[challenge sender] useCredential:credential forAuthenticationChallenge:challenge];
+                } else {
+                    SecTrustResultType result = 0;
+                    OSStatus status = SecTrustEvaluate(serverTrust, &result);
+                    NSAssert(status == errSecSuccess, @"SecTrustEvaluate error: %ld", (long int)status);
+                    
+                    if (status == errSecSuccess && (result == kSecTrustResultUnspecified || result == kSecTrustResultProceed)) {
+                        NSURLCredential *credential = [NSURLCredential credentialForTrust:serverTrust];
+                        [[challenge sender] useCredential:credential forAuthenticationChallenge:challenge];
+                    } else {
+                        [[challenge sender] cancelAuthenticationChallenge:challenge];
+                    }
+                }
+                break;
+            }
+        }
+    } else {
+        if ([challenge previousFailureCount] == 0) {
+            if (self.credential) {
+                [[challenge sender] useCredential:self.credential forAuthenticationChallenge:challenge];
+            } else {
+                [[challenge sender] continueWithoutCredentialForAuthenticationChallenge:challenge];
+            }
+        } else {
+            [[challenge sender] continueWithoutCredentialForAuthenticationChallenge:challenge];
+        }
+    }
+}
+
+- (BOOL)connectionShouldUseCredentialStorage:(NSURLConnection __unused *)connection {
+    return self.shouldUseCredentialStorage;
+}
+
+- (NSURLRequest *)connection:(NSURLConnection *)connection
+             willSendRequest:(NSURLRequest *)request
+            redirectResponse:(NSURLResponse *)redirectResponse
+{
+    if (self.redirectResponse) {
+        return self.redirectResponse(connection, request, redirectResponse);
+    } else {
+        return request;
+    }
+}
+
+- (void)connection:(NSURLConnection __unused *)connection
+   didSendBodyData:(NSInteger)bytesWritten
+ totalBytesWritten:(NSInteger)totalBytesWritten
+totalBytesExpectedToWrite:(NSInteger)totalBytesExpectedToWrite
+{
+    if (self.uploadProgress) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            self.uploadProgress((NSUInteger)bytesWritten, totalBytesWritten, totalBytesExpectedToWrite);
+        });
+    }
+}
+
+- (void)connection:(NSURLConnection __unused *)connection
+didReceiveResponse:(NSURLResponse *)response
+{
+    self.response = response;
+    
+    [self.outputStream open];
+}
+
+- (void)connection:(NSURLConnection __unused *)connection
+    didReceiveData:(NSData *)data
+{
+    NSUInteger length = [data length];
+    while (YES) {
+        NSUInteger totalNumberOfBytesWritten = 0;
+        if ([self.outputStream hasSpaceAvailable]) {
+            const uint8_t *dataBuffer = (uint8_t *)[data bytes];
+
+            NSInteger numberOfBytesWritten = 0;
+            while (totalNumberOfBytesWritten < length) {
+                numberOfBytesWritten = [self.outputStream write:&dataBuffer[0] maxLength:length];
+                if (numberOfBytesWritten == -1) {
+                    [self.connection cancel];
+                    [self performSelector:@selector(connection:didFailWithError:) withObject:self.connection withObject:self.outputStream.streamError];
+                    return;
+                } else {
+                    totalNumberOfBytesWritten += numberOfBytesWritten;
+                }
+            }
+
+            break;
+        }
+    }
+    
+    dispatch_async(dispatch_get_main_queue(), ^{
+        self.totalBytesRead += length;
+        
+        if (self.downloadProgress) {
+            self.downloadProgress(length, self.totalBytesRead, self.response.expectedContentLength);
+        }
+    });
+}
+
+- (void)connectionDidFinishLoading:(NSURLConnection __unused *)connection {
+    self.responseData = [self.outputStream propertyForKey:NSStreamDataWrittenToMemoryStreamKey];
+    
+    [self.outputStream close];
+    
+    [self finish];
+    
+    self.connection = nil;
+}
+
+- (void)connection:(NSURLConnection __unused *)connection
+  didFailWithError:(NSError *)error
+{
+    self.error = error;
+    
+    [self.outputStream close];
+    
+    [self finish];
+    
+    self.connection = nil;
+}
+
+- (NSCachedURLResponse *)connection:(NSURLConnection *)connection
+                  willCacheResponse:(NSCachedURLResponse *)cachedResponse
+{
+    if (self.cacheResponse) {
+        return self.cacheResponse(connection, cachedResponse);
+    } else {
+        if ([self isCancelled]) {
+            return nil;
+        }
+        
+        return cachedResponse;
+    }
+}
+
+#pragma mark - NSCoding
+
+- (id)initWithCoder:(NSCoder *)aDecoder {
+    NSURLRequest *request = [aDecoder decodeObjectForKey:@"request"];
+    
+    self = [self initWithRequest:request];
+    if (!self) {
+        return nil;
+    }
+    
+    self.state = (HatenaAFOperationState)[aDecoder decodeIntegerForKey:@"state"];
+    self.cancelled = [aDecoder decodeBoolForKey:@"isCancelled"];
+    self.response = [aDecoder decodeObjectForKey:@"response"];
+    self.error = [aDecoder decodeObjectForKey:@"error"];
+    self.responseData = [aDecoder decodeObjectForKey:@"responseData"];
+    self.totalBytesRead = [[aDecoder decodeObjectForKey:@"totalBytesRead"] longLongValue];
+    self.allowsInvalidSSLCertificate = [[aDecoder decodeObjectForKey:@"allowsInvalidSSLCertificate"] boolValue];
+
+    return self;
+}
+
+- (void)encodeWithCoder:(NSCoder *)aCoder {
+    [self pause];
+    
+    [aCoder encodeObject:self.request forKey:@"request"];
+    
+    switch (self.state) {
+        case HatenaAFOperationExecutingState:
+        case HatenaAFOperationPausedState:
+            [aCoder encodeInteger:HatenaAFOperationReadyState forKey:@"state"];
+            break;
+        default:
+            [aCoder encodeInteger:self.state forKey:@"state"];
+            break;
+    }
+    
+    [aCoder encodeBool:[self isCancelled] forKey:@"isCancelled"];
+    [aCoder encodeObject:self.response forKey:@"response"];
+    [aCoder encodeObject:self.error forKey:@"error"];
+    [aCoder encodeObject:self.responseData forKey:@"responseData"];
+    [aCoder encodeObject:[NSNumber numberWithLongLong:self.totalBytesRead] forKey:@"totalBytesRead"];
+    [aCoder encodeObject:[NSNumber numberWithBool:self.allowsInvalidSSLCertificate] forKey:@"allowsInvalidSSLCertificate"];
+}
+
+#pragma mark - NSCopying
+
+- (id)copyWithZone:(NSZone *)zone {
+    HatenaAFURLConnectionOperation *operation = [(HatenaAFURLConnectionOperation *)[[self class] allocWithZone:zone] initWithRequest:self.request];
+    
+    operation.uploadProgress = self.uploadProgress;
+    operation.downloadProgress = self.downloadProgress;
+    operation.authenticationChallenge = self.authenticationChallenge;
+    operation.cacheResponse = self.cacheResponse;
+    operation.redirectResponse = self.redirectResponse;
+    operation.allowsInvalidSSLCertificate = self.allowsInvalidSSLCertificate;
+    
+    return operation;
+}
+
+@end

--- a/SDK/API/AFNetworking/HatenaAFURLConnectionOperation.m
+++ b/SDK/API/AFNetworking/HatenaAFURLConnectionOperation.m
@@ -592,6 +592,7 @@ willSendRequestForAuthenticationChallenge:(NSURLAuthenticationChallenge *)challe
         SecTrustRef serverTrust = challenge.protectionSpace.serverTrust;
         
         SecPolicyRef policy = SecPolicyCreateBasicX509();
+        SecTrustEvaluate(serverTrust, NULL);
         CFIndex certificateCount = SecTrustGetCertificateCount(serverTrust);
         NSMutableArray *trustChain = [NSMutableArray arrayWithCapacity:certificateCount];
         
@@ -738,15 +739,19 @@ didReceiveResponse:(NSURLResponse *)response
             while (totalNumberOfBytesWritten < length) {
                 numberOfBytesWritten = [self.outputStream write:&dataBuffer[0] maxLength:length];
                 if (numberOfBytesWritten == -1) {
-                    [self.connection cancel];
-                    [self performSelector:@selector(connection:didFailWithError:) withObject:self.connection withObject:self.outputStream.streamError];
-                    return;
-                } else {
-                    totalNumberOfBytesWritten += numberOfBytesWritten;
+                    break;
                 }
+
+                totalNumberOfBytesWritten += numberOfBytesWritten;
             }
 
             break;
+        }
+
+        if (self.outputStream.streamError) {
+            [self.connection cancel];
+            [self performSelector:@selector(connection:didFailWithError:) withObject:self.connection withObject:self.outputStream.streamError];
+            return;
         }
     }
     

--- a/SDK/API/AFNetworking/HatenaAFXMLRequestOperation.h
+++ b/SDK/API/AFNetworking/HatenaAFXMLRequestOperation.h
@@ -1,0 +1,89 @@
+// HatenaAFXMLRequestOperation.h
+//
+// Copyright (c) 2011 Gowalla (http://gowalla.com/)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <Foundation/Foundation.h>
+#import "HatenaAFHTTPRequestOperation.h"
+
+#import <Availability.h>
+
+/**
+ `HatenaAFXMLRequestOperation` is a subclass of `HatenaAFHTTPRequestOperation` for downloading and working with XML response data.
+
+ ## Acceptable Content Types
+
+ By default, `HatenaAFXMLRequestOperation` accepts the following MIME types, which includes the official standard, `application/xml`, as well as other commonly-used types:
+
+ - `application/xml`
+ - `text/xml`
+
+ ## Use With HatenaAFHTTPClient
+
+ When `HatenaAFXMLRequestOperation` is registered with `HatenaAFHTTPClient`, the response object in the success callback of `HTTPRequestOperationWithRequest:success:failure:` will be an instance of `NSXMLParser`. On platforms that support `NSXMLDocument`, you have the option to ignore the response object, and simply use the `responseXMLDocument` property of the operation argument of the callback.
+ */
+@interface HatenaAFXMLRequestOperation : HatenaAFHTTPRequestOperation
+
+///----------------------------
+/// @name Getting Response Data
+///----------------------------
+
+/**
+ An `NSXMLParser` object constructed from the response data.
+ */
+@property (readonly, nonatomic, strong) NSXMLParser *responseXMLParser;
+
+#ifdef __MAC_OS_X_VERSION_MIN_REQUIRED
+/**
+ An `NSXMLDocument` object constructed from the response data. If an error occurs while parsing, `nil` will be returned, and the `error` property will be set to the error.
+ */
+@property (readonly, nonatomic, strong) NSXMLDocument *responseXMLDocument;
+#endif
+
+/**
+ Creates and returns an `HatenaAFXMLRequestOperation` object and sets the specified success and failure callbacks.
+
+ @param urlRequest The request object to be loaded asynchronously during execution of the operation
+ @param success A block object to be executed when the operation finishes successfully. This block has no return value and takes three arguments: the request sent from the client, the response received from the server, and the XML parser constructed with the response data of request.
+ @param failure A block object to be executed when the operation finishes unsuccessfully. This block has no return value and takes three arguments: the request sent from the client, the response received from the server, and the error describing the network error that occurred.
+
+ @return A new XML request operation
+ */
++ (instancetype)XMLParserRequestOperationWithRequest:(NSURLRequest *)urlRequest
+											 success:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSXMLParser *XMLParser))success
+											 failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error, NSXMLParser *XMLParser))failure;
+
+
+#ifdef __MAC_OS_X_VERSION_MIN_REQUIRED
+/**
+ Creates and returns an `HatenaAFXMLRequestOperation` object and sets the specified success and failure callbacks.
+
+ @param urlRequest The request object to be loaded asynchronously during execution of the operation
+ @param success A block object to be executed when the operation finishes successfully. This block has no return value and takes three arguments: the request sent from the client, the response received from the server, and the XML document created from the response data of request.
+ @param failure A block object to be executed when the operation finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the response data as XML. This block has no return value and takes three arguments: the request sent from the client, the response received from the server, and the error describing the network or parsing error that occurred.
+
+ @return A new XML request operation
+ */
++ (instancetype)XMLDocumentRequestOperationWithRequest:(NSURLRequest *)urlRequest
+											   success:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSXMLDocument *document))success
+											   failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error, NSXMLDocument *document))failure;
+#endif
+
+@end

--- a/SDK/API/AFNetworking/HatenaAFXMLRequestOperation.m
+++ b/SDK/API/AFNetworking/HatenaAFXMLRequestOperation.m
@@ -1,0 +1,167 @@
+// HatenaAFXMLRequestOperation.m
+//
+// Copyright (c) 2011 Gowalla (http://gowalla.com/)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "HatenaAFXMLRequestOperation.h"
+
+#include <Availability.h>
+
+static dispatch_queue_t xml_request_operation_processing_queue() {
+    static dispatch_queue_t af_xml_request_operation_processing_queue;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        af_xml_request_operation_processing_queue = dispatch_queue_create("com.alamofire.networking.xml-request.processing", DISPATCH_QUEUE_CONCURRENT);
+    });
+
+    return af_xml_request_operation_processing_queue;
+}
+
+@interface HatenaAFXMLRequestOperation ()
+@property (readwrite, nonatomic, strong) NSXMLParser *responseXMLParser;
+#ifdef __MAC_OS_X_VERSION_MIN_REQUIRED
+@property (readwrite, nonatomic, strong) NSXMLDocument *responseXMLDocument;
+#endif
+@property (readwrite, nonatomic, strong) NSError *XMLError;
+@end
+
+@implementation HatenaAFXMLRequestOperation
+@synthesize responseXMLParser = _responseXMLParser;
+#ifdef __MAC_OS_X_VERSION_MIN_REQUIRED
+@synthesize responseXMLDocument = _responseXMLDocument;
+#endif
+@synthesize XMLError = _XMLError;
+
++ (instancetype)XMLParserRequestOperationWithRequest:(NSURLRequest *)urlRequest
+											 success:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSXMLParser *XMLParser))success
+											 failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error, NSXMLParser *XMLParser))failure
+{
+    HatenaAFXMLRequestOperation *requestOperation = [(HatenaAFXMLRequestOperation *)[self alloc] initWithRequest:urlRequest];
+    [requestOperation setCompletionBlockWithSuccess:^(HatenaAFHTTPRequestOperation *operation, id responseObject) {
+        if (success) {
+            success(operation.request, operation.response, responseObject);
+        }
+    } failure:^(HatenaAFHTTPRequestOperation *operation, NSError *error) {
+        if (failure) {
+            failure(operation.request, operation.response, error, [(HatenaAFXMLRequestOperation *)operation responseXMLParser]);
+        }
+    }];
+
+    return requestOperation;
+}
+
+#ifdef __MAC_OS_X_VERSION_MIN_REQUIRED
++ (instancetype)XMLDocumentRequestOperationWithRequest:(NSURLRequest *)urlRequest
+											   success:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSXMLDocument *document))success
+											   failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error, NSXMLDocument *document))failure
+{
+    HatenaAFXMLRequestOperation *requestOperation = [[self alloc] initWithRequest:urlRequest];
+    [requestOperation setCompletionBlockWithSuccess:^(HatenaAFHTTPRequestOperation *operation, __unused id responseObject) {
+        if (success) {
+            NSXMLDocument *XMLDocument = [(HatenaAFXMLRequestOperation *)operation responseXMLDocument];
+            success(operation.request, operation.response, XMLDocument);
+        }
+    } failure:^(HatenaAFHTTPRequestOperation *operation, NSError *error) {
+        if (failure) {
+            NSXMLDocument *XMLDocument = [(HatenaAFXMLRequestOperation *)operation responseXMLDocument];
+            failure(operation.request, operation.response, error, XMLDocument);
+        }
+    }];
+
+    return requestOperation;
+}
+#endif
+
+
+- (NSXMLParser *)responseXMLParser {
+    if (!_responseXMLParser && [self.responseData length] > 0 && [self isFinished]) {
+        self.responseXMLParser = [[NSXMLParser alloc] initWithData:self.responseData];
+    }
+
+    return _responseXMLParser;
+}
+
+#ifdef __MAC_OS_X_VERSION_MIN_REQUIRED
+- (NSXMLDocument *)responseXMLDocument {
+    if (!_responseXMLDocument && [self.responseData length] > 0 && [self isFinished]) {
+        NSError *error = nil;
+        self.responseXMLDocument = [[NSXMLDocument alloc] initWithData:self.responseData options:0 error:&error];
+        self.XMLError = error;
+    }
+
+    return _responseXMLDocument;
+}
+#endif
+
+- (NSError *)error {
+    if (_XMLError) {
+        return _XMLError;
+    } else {
+        return [super error];
+    }
+}
+
+#pragma mark - NSOperation
+
+- (void)cancel {
+    [super cancel];
+
+    self.responseXMLParser.delegate = nil;
+}
+
+#pragma mark - HatenaAFHTTPRequestOperation
+
++ (NSSet *)acceptableContentTypes {
+    return [NSSet setWithObjects:@"application/xml", @"text/xml", nil];
+}
+
++ (BOOL)canProcessRequest:(NSURLRequest *)request {
+    return [[[request URL] pathExtension] isEqualToString:@"xml"] || [super canProcessRequest:request];
+}
+
+- (void)setCompletionBlockWithSuccess:(void (^)(HatenaAFHTTPRequestOperation *operation, id responseObject))success
+                              failure:(void (^)(HatenaAFHTTPRequestOperation *operation, NSError *error))failure
+{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-retain-cycles"
+#pragma clang diagnostic ignored "-Wgnu"
+    self.completionBlock = ^ {
+        dispatch_async(xml_request_operation_processing_queue(), ^(void) {
+            NSXMLParser *XMLParser = self.responseXMLParser;
+
+            if (self.error) {
+                if (failure) {
+                    dispatch_async(self.failureCallbackQueue ?: dispatch_get_main_queue(), ^{
+                        failure(self, self.error);
+                    });
+                }
+            } else {
+                if (success) {
+                    dispatch_async(self.successCallbackQueue ?: dispatch_get_main_queue(), ^{
+                        success(self, XMLParser);
+                    });
+                }
+            }
+        });
+    };
+#pragma clang diagnostic pop
+}
+
+@end

--- a/SDK/API/AFNetworking/UIImageView+HatenaAFNetworking.h
+++ b/SDK/API/AFNetworking/UIImageView+HatenaAFNetworking.h
@@ -1,0 +1,78 @@
+// UIImageView+HatenaAFNetworking.h
+//
+// Copyright (c) 2011 Gowalla (http://gowalla.com/)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <Foundation/Foundation.h>
+#import "HatenaAFImageRequestOperation.h"
+
+#import <Availability.h>
+
+#if __IPHONE_OS_VERSION_MIN_REQUIRED
+#import <UIKit/UIKit.h>
+
+/**
+ This category adds methods to the UIKit framework's `UIImageView` class. The methods in this category provide support for loading remote images asynchronously from a URL.
+ */
+@interface UIImageView (HatenaAFNetworking)
+
+/**
+ Creates and enqueues an image request operation, which asynchronously downloads the image from the specified URL, and sets it the request is finished. Any previous image request for the receiver will be cancelled. If the image is cached locally, the image is set immediately, otherwise the specified placeholder image will be set immediately, and then the remote image will be set once the request is finished.
+
+ By default, URL requests have a cache policy of `NSURLCacheStorageAllowed` and a timeout interval of 30 seconds, and are set not handle cookies. To configure URL requests differently, use `setImageWithURLRequest:placeholderImage:success:failure:`
+
+ @param url The URL used for the image request.
+ */
+- (void)setImageWithURL:(NSURL *)url;
+
+/**
+ Creates and enqueues an image request operation, which asynchronously downloads the image from the specified URL. Any previous image request for the receiver will be cancelled. If the image is cached locally, the image is set immediately, otherwise the specified placeholder image will be set immediately, and then the remote image will be set once the request is finished.
+
+ By default, URL requests have a cache policy of `NSURLCacheStorageAllowed` and a timeout interval of 30 seconds, and are set not handle cookies. To configure URL requests differently, use `setImageWithURLRequest:placeholderImage:success:failure:`
+ 
+ @param url The URL used for the image request.
+ @param placeholderImage The image to be set initially, until the image request finishes. If `nil`, the image view will not change its image until the image request finishes.
+ */
+- (void)setImageWithURL:(NSURL *)url
+       placeholderImage:(UIImage *)placeholderImage;
+
+/**
+ Creates and enqueues an image request operation, which asynchronously downloads the image with the specified URL request object. Any previous image request for the receiver will be cancelled. If the image is cached locally, the image is set immediately, otherwise the specified placeholder image will be set immediately, and then the remote image will be set once the request is finished.
+ 
+ If a success block is specified, it is the responsibility of the block to set the image of the image view before returning. If no success block is specified, the default behavior of setting the image with `self.image = image` is executed.
+
+ @param urlRequest The URL request used for the image request.
+ @param placeholderImage The image to be set initially, until the image request finishes. If `nil`, the image view will not change its image until the image request finishes.
+ @param success A block to be executed when the image request operation finishes successfully, with a status code in the 2xx range, and with an acceptable content type (e.g. `image/png`). This block has no return value and takes three arguments: the request sent from the client, the response received from the server, and the image created from the response data of request. If the image was returned from cache, the request and response parameters will be `nil`.
+ @param failure A block object to be executed when the image request operation finishes unsuccessfully, or that finishes successfully. This block has no return value and takes three arguments: the request sent from the client, the response received from the server, and the error object describing the network or parsing error that occurred.
+ */
+- (void)setImageWithURLRequest:(NSURLRequest *)urlRequest
+              placeholderImage:(UIImage *)placeholderImage
+                       success:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, UIImage *image))success
+                       failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error))failure;
+
+/**
+ Cancels any executing image request operation for the receiver, if one exists.
+ */
+- (void)cancelImageRequestOperation;
+
+@end
+
+#endif

--- a/SDK/API/AFNetworking/UIImageView+HatenaAFNetworking.m
+++ b/SDK/API/AFNetworking/UIImageView+HatenaAFNetworking.m
@@ -1,0 +1,191 @@
+// UIImageView+HatenaAFNetworking.m
+//
+// Copyright (c) 2011 Gowalla (http://gowalla.com/)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <Foundation/Foundation.h>
+#import <objc/runtime.h>
+
+#if defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
+#import "UIImageView+HatenaAFNetworking.h"
+
+@interface HatenaAFImageCache : NSCache
+- (UIImage *)cachedImageForRequest:(NSURLRequest *)request;
+- (void)cacheImage:(UIImage *)image
+        forRequest:(NSURLRequest *)request;
+@end
+
+#pragma mark -
+
+static char kHatenaAFImageRequestOperationObjectKey;
+
+@interface UIImageView (_HatenaAFNetworking)
+@property (readwrite, nonatomic, strong, setter = af_setImageRequestOperation:) HatenaAFImageRequestOperation *af_imageRequestOperation;
+@end
+
+@implementation UIImageView (_HatenaAFNetworking)
+@dynamic af_imageRequestOperation;
+@end
+
+#pragma mark -
+
+@implementation UIImageView (HatenaAFNetworking)
+
+- (HatenaAFHTTPRequestOperation *)af_imageRequestOperation {
+    return (HatenaAFHTTPRequestOperation *)objc_getAssociatedObject(self, &kHatenaAFImageRequestOperationObjectKey);
+}
+
+- (void)af_setImageRequestOperation:(HatenaAFImageRequestOperation *)imageRequestOperation {
+    objc_setAssociatedObject(self, &kHatenaAFImageRequestOperationObjectKey, imageRequestOperation, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
++ (NSOperationQueue *)af_sharedImageRequestOperationQueue {
+    static NSOperationQueue *_af_imageRequestOperationQueue = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        _af_imageRequestOperationQueue = [[NSOperationQueue alloc] init];
+        [_af_imageRequestOperationQueue setMaxConcurrentOperationCount:NSOperationQueueDefaultMaxConcurrentOperationCount];
+    });
+
+    return _af_imageRequestOperationQueue;
+}
+
++ (HatenaAFImageCache *)af_sharedImageCache {
+    static HatenaAFImageCache *_af_imageCache = nil;
+    static dispatch_once_t oncePredicate;
+    dispatch_once(&oncePredicate, ^{
+        _af_imageCache = [[HatenaAFImageCache alloc] init];
+    });
+
+    return _af_imageCache;
+}
+
+#pragma mark -
+
+- (void)setImageWithURL:(NSURL *)url {
+    [self setImageWithURL:url placeholderImage:nil];
+}
+
+- (void)setImageWithURL:(NSURL *)url
+       placeholderImage:(UIImage *)placeholderImage
+{
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url];
+    [request addValue:@"image/*" forHTTPHeaderField:@"Accept"];
+
+    [self setImageWithURLRequest:request placeholderImage:placeholderImage success:nil failure:nil];
+}
+
+- (void)setImageWithURLRequest:(NSURLRequest *)urlRequest
+              placeholderImage:(UIImage *)placeholderImage
+                       success:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, UIImage *image))success
+                       failure:(void (^)(NSURLRequest *request, NSHTTPURLResponse *response, NSError *error))failure
+{
+    [self cancelImageRequestOperation];
+
+    UIImage *cachedImage = [[[self class] af_sharedImageCache] cachedImageForRequest:urlRequest];
+    if (cachedImage) {
+        self.af_imageRequestOperation = nil;
+
+        if (success) {
+            success(nil, nil, cachedImage);
+        } else {
+            self.image = cachedImage;
+        }
+    } else {
+        if (placeholderImage) {
+            self.image = placeholderImage;
+        }
+
+        HatenaAFImageRequestOperation *requestOperation = [[HatenaAFImageRequestOperation alloc] initWithRequest:urlRequest];
+		
+#ifdef _HatenaAFNETWORKING_ALLOW_INVALID_SSL_CERTIFICATES_
+		requestOperation.allowsInvalidSSLCertificate = YES;
+#endif
+		
+        [requestOperation setCompletionBlockWithSuccess:^(HatenaAFHTTPRequestOperation *operation, id responseObject) {
+            if ([urlRequest isEqual:[self.af_imageRequestOperation request]]) {
+                if (self.af_imageRequestOperation == operation) {
+                    self.af_imageRequestOperation = nil;
+                }
+
+                if (success) {
+                    success(operation.request, operation.response, responseObject);
+                } else if (responseObject) {
+                    self.image = responseObject;
+                }
+            }
+
+            [[[self class] af_sharedImageCache] cacheImage:responseObject forRequest:urlRequest];
+        } failure:^(HatenaAFHTTPRequestOperation *operation, NSError *error) {
+            if ([urlRequest isEqual:[self.af_imageRequestOperation request]]) {
+                if (self.af_imageRequestOperation == operation) {
+                    self.af_imageRequestOperation = nil;
+                }
+
+                if (failure) {
+                    failure(operation.request, operation.response, error);
+                }
+            }
+        }];
+
+        self.af_imageRequestOperation = requestOperation;
+
+        [[[self class] af_sharedImageRequestOperationQueue] addOperation:self.af_imageRequestOperation];
+    }
+}
+
+- (void)cancelImageRequestOperation {
+    [self.af_imageRequestOperation cancel];
+    self.af_imageRequestOperation = nil;
+}
+
+@end
+
+#pragma mark -
+
+static inline NSString * HatenaAFImageCacheKeyFromURLRequest(NSURLRequest *request) {
+    return [[request URL] absoluteString];
+}
+
+@implementation HatenaAFImageCache
+
+- (UIImage *)cachedImageForRequest:(NSURLRequest *)request {
+    switch ([request cachePolicy]) {
+        case NSURLRequestReloadIgnoringCacheData:
+        case NSURLRequestReloadIgnoringLocalAndRemoteCacheData:
+            return nil;
+        default:
+            break;
+    }
+
+	return [self objectForKey:HatenaAFImageCacheKeyFromURLRequest(request)];
+}
+
+- (void)cacheImage:(UIImage *)image
+        forRequest:(NSURLRequest *)request
+{
+    if (image && request) {
+        [self setObject:image forKey:HatenaAFImageCacheKeyFromURLRequest(request)];
+    }
+}
+
+@end
+
+#endif

--- a/SDK/API/HTBAFOAuth1Client.h
+++ b/SDK/API/HTBAFOAuth1Client.h
@@ -25,7 +25,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#import "AFHTTPClient.h"
+#import "HatenaAFHTTPClient.h"
 
 typedef enum {
     AFHMACSHA1SignatureMethod = 1,
@@ -36,7 +36,7 @@ typedef enum {
 /**
 
  */
-@interface HTBAFOAuth1Client : AFHTTPClient <NSCoding, NSCopying>
+@interface HTBAFOAuth1Client : HatenaAFHTTPClient <NSCoding, NSCopying>
 
 ///-----------------------------------
 /// @name Managing OAuth Configuration

--- a/SDK/API/HTBAFOAuth1Client.m
+++ b/SDK/API/HTBAFOAuth1Client.m
@@ -25,7 +25,7 @@
 // THE SOFTWARE.
 
 #import "HTBAFOAuth1Client.h"
-#import "AFHTTPRequestOperation.h"
+#import "HatenaAFHTTPRequestOperation.h"
 
 #import <CommonCrypto/CommonHMAC.h>
 
@@ -256,7 +256,7 @@ static inline NSString * AFHMACSHA1Signature(NSURLRequest *request, NSString *co
     [mutableParameters addEntriesFromDictionary:mutableAuthorizationParameters];
     [mutableAuthorizationParameters setValue:[self OAuthSignatureForMethod:method path:path parameters:mutableParameters token:self.accessToken] forKey:@"oauth_signature"];
     
-    NSArray *sortedComponents = [[AFQueryStringFromParametersWithEncoding(mutableAuthorizationParameters, self.stringEncoding) componentsSeparatedByString:@"&"] sortedArrayUsingSelector:@selector(caseInsensitiveCompare:)];
+    NSArray *sortedComponents = [[HatenaAFQueryStringFromParametersWithEncoding(mutableAuthorizationParameters, self.stringEncoding) componentsSeparatedByString:@"&"] sortedArrayUsingSelector:@selector(caseInsensitiveCompare:)];
     NSMutableArray *mutableComponents = [NSMutableArray array];
     for (NSString *component in sortedComponents) {
         NSArray *subcomponents = [component componentsSeparatedByString:@"="];
@@ -337,12 +337,12 @@ static inline NSString * AFHMACSHA1Signature(NSURLRequest *request, NSString *co
 
     NSMutableURLRequest *request = [self requestWithMethod:accessMethod path:path parameters:parameters];
     
-    AFHTTPRequestOperation *operation = [self HTTPRequestOperationWithRequest:request success:^(AFHTTPRequestOperation *operation, id responseObject) {
+    HatenaAFHTTPRequestOperation *operation = [self HTTPRequestOperationWithRequest:request success:^(HatenaAFHTTPRequestOperation *operation, id responseObject) {
         if (success) {
             AFOAuth1Token *accessToken = [[AFOAuth1Token alloc] initWithQueryString:operation.responseString];
             success(accessToken, responseObject);
         }
-    } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+    } failure:^(HatenaAFHTTPRequestOperation *operation, NSError *error) {
         if (failure) {
             failure(error);
         }
@@ -365,12 +365,12 @@ static inline NSString * AFHMACSHA1Signature(NSURLRequest *request, NSString *co
 
     NSMutableURLRequest *request = [self requestWithMethod:accessMethod path:path parameters:parameters];
 
-    AFHTTPRequestOperation *operation = [self HTTPRequestOperationWithRequest:request success:^(AFHTTPRequestOperation *operation, id responseObject) {
+    HatenaAFHTTPRequestOperation *operation = [self HTTPRequestOperationWithRequest:request success:^(HatenaAFHTTPRequestOperation *operation, id responseObject) {
         if (success) {
             AFOAuth1Token *accessToken = [[AFOAuth1Token alloc] initWithQueryString:operation.responseString];
             success(accessToken, responseObject);
         }
-    } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+    } failure:^(HatenaAFHTTPRequestOperation *operation, NSError *error) {
         if (failure) {
             failure(error);
         }
@@ -403,7 +403,7 @@ static inline NSString * AFHMACSHA1Signature(NSURLRequest *request, NSString *co
 - (NSMutableURLRequest *)multipartFormRequestWithMethod:(NSString *)method
                                                    path:(NSString *)path
                                              parameters:(NSDictionary *)parameters
-                              constructingBodyWithBlock:(void (^)(id <AFMultipartFormData> formData))block
+                              constructingBodyWithBlock:(void (^)(id <HatenaAFMultipartFormData> formData))block
 {
     NSMutableURLRequest *request = [super multipartFormRequestWithMethod:method path:path parameters:parameters constructingBodyWithBlock:block];
     [request setValue:[self authorizationHeaderForMethod:method path:path parameters:parameters] forHTTPHeaderField:@"Authorization"];

--- a/SDK/API/HTBHatenaBookmarkAPIClient.h
+++ b/SDK/API/HTBHatenaBookmarkAPIClient.h
@@ -50,39 +50,39 @@ extern NSString * const kHTBApplicationLaunchOptionsURLKey;
                      failure:(void (^)(NSError *error))failure;
 
 // Get your user information.
-- (void)getMyWithSuccess:(void (^)(AFHTTPRequestOperation *operation, id responseJSON))success
-                 failure:(void (^)(AFHTTPRequestOperation *operation, NSError *error))failure;
+- (void)getMyWithSuccess:(void (^)(HatenaAFHTTPRequestOperation *operation, id responseJSON))success
+                 failure:(void (^)(HatenaAFHTTPRequestOperation *operation, NSError *error))failure;
 
 // Get your tags.
-- (void)getMyTagsWithSuccess:(void (^)(AFHTTPRequestOperation *operation, id responseJSON))success
-                 failure:(void (^)(AFHTTPRequestOperation *operation, NSError *error))failure;
+- (void)getMyTagsWithSuccess:(void (^)(HatenaAFHTTPRequestOperation *operation, id responseJSON))success
+                     failure:(void (^)(HatenaAFHTTPRequestOperation *operation, NSError *error))failure;
 
 // Get public entry information.
 - (void)getEntryWithURL:(NSURL *)bookmarkURL
-                success:(void (^)(AFHTTPRequestOperation *operation, id responseJSON))success
-                failure:(void (^)(AFHTTPRequestOperation *operation, NSError *error))failure;
+                success:(void (^)(HatenaAFHTTPRequestOperation *operation, id responseJSON))success
+                failure:(void (^)(HatenaAFHTTPRequestOperation *operation, NSError *error))failure;
 
 // Get canonical information.
 - (void)getCanonicalEntryWithURL:(NSURL *)bookmarkURL
-                success:(void (^)(AFHTTPRequestOperation *operation, id responseJSON))success
-                failure:(void (^)(AFHTTPRequestOperation *operation, NSError *error))failure;
+                success:(void (^)(HatenaAFHTTPRequestOperation *operation, id responseJSON))success
+                failure:(void (^)(HatenaAFHTTPRequestOperation *operation, NSError *error))failure;
 
 // Get your bookmark information.
 - (void)getBookmarkWithURL:(NSURL *)bookmarkURL
-                   success:(void (^)(AFHTTPRequestOperation *operation, id responseJSON))success
-                   failure:(void (^)(AFHTTPRequestOperation *operation, NSError *error))failure;
+                   success:(void (^)(HatenaAFHTTPRequestOperation *operation, id responseJSON))success
+                   failure:(void (^)(HatenaAFHTTPRequestOperation *operation, NSError *error))failure;
 
 // Add or edit your bookmark.
 - (void)postBookmarkWithURL:(NSURL *)bookmarkURL
                     comment:(NSString *)comment
                        tags:(NSArray *)tags
                     options:(HatenaBookmarkPOSTOptions)options
-                    success:(void (^)(AFHTTPRequestOperation *operation, id responseJSON))success
-                    failure:(void (^)(AFHTTPRequestOperation *operation, NSError *error))failure;
+                    success:(void (^)(HatenaAFHTTPRequestOperation *operation, id responseJSON))success
+                    failure:(void (^)(HatenaAFHTTPRequestOperation *operation, NSError *error))failure;
 
 // Delete your bookmark.
 - (void)deleteBookmarkWithURL:(NSURL *)bookmarkURL
-                      success:(void (^)(AFHTTPRequestOperation *operation, id responseJSON))success
-                      failure:(void (^)(AFHTTPRequestOperation *operation, NSError *error))failure;
+                      success:(void (^)(HatenaAFHTTPRequestOperation *operation, id responseJSON))success
+                      failure:(void (^)(HatenaAFHTTPRequestOperation *operation, NSError *error))failure;
 
 @end

--- a/SDK/API/HTBHatenaBookmarkAPIClient.m
+++ b/SDK/API/HTBHatenaBookmarkAPIClient.m
@@ -23,7 +23,7 @@
 #import "HTBHatenaBookmarkAPIClient.h"
 
 #import "HTBAFOAuth1Client.h"
-#import "AFJSONRequestOperation.h"
+#import "HatenaAFJSONRequestOperation.h"
 
 #import "HTBUserManager.h"
 
@@ -85,8 +85,8 @@ static NSDictionary * HTBParametersFromQueryString(NSString *queryString) {
 {
     self = [super initWithBaseURL:[NSURL URLWithString:kHatenaBookmarkBaseURLString] key:key secret:secret];
     if (self) {
-        [self registerHTTPOperationClass:[AFHTTPRequestOperation class]];
-        [self registerHTTPOperationClass:[AFJSONRequestOperation class]];
+        [self registerHTTPOperationClass:[HatenaAFHTTPRequestOperation class]];
+        [self registerHTTPOperationClass:[HatenaAFJSONRequestOperation class]];
     }
     return self;
 }
@@ -98,7 +98,7 @@ static NSDictionary * HTBParametersFromQueryString(NSString *queryString) {
 
         NSMutableDictionary *parameters = [@{} mutableCopy];
         [parameters setValue:requestToken.key forKey:@"oauth_token"];
-        NSMutableURLRequest *request = [[[AFHTTPClient alloc] initWithBaseURL:[NSURL URLWithString:kHatenaBookmarkBaseURLString]] requestWithMethod:@"GET" path:kHatenaOAuthUserAuthorizationPath parameters:parameters];
+        NSMutableURLRequest *request = [[[HatenaAFHTTPClient alloc] initWithBaseURL:[NSURL URLWithString:kHatenaBookmarkBaseURLString]] requestWithMethod:@"GET" path:kHatenaOAuthUserAuthorizationPath parameters:parameters];
         request.HTTPShouldHandleCookies = NO;
         __block AFOAuth1Token *currentRequestToken = requestToken;
         
@@ -144,8 +144,8 @@ static NSDictionary * HTBParametersFromQueryString(NSString *queryString) {
                              comment:(NSString *)comment
                                 tags:(NSArray *)tags
                              options:(HatenaBookmarkPOSTOptions)options
-                             success:(void (^)(AFHTTPRequestOperation *operation, id responseJSON))success
-                             failure:(void (^)(AFHTTPRequestOperation *operation, NSError *error))failure
+                             success:(void (^)(HatenaAFHTTPRequestOperation *operation, id responseJSON))success
+                             failure:(void (^)(HatenaAFHTTPRequestOperation *operation, NSError *error))failure
 {
     NSString *path = @"/1/my/bookmark.json";
     NSDictionary *parameters = @{
@@ -159,11 +159,11 @@ static NSDictionary * HTBParametersFromQueryString(NSString *queryString) {
         @"send_mail"     : [NSNumber numberWithBool:options & HatenaBookmarkPostOptionSendMail],
         @"private"       : [NSNumber numberWithBool:options & HatenaBookmarkPostOptionPrivate],
     };    
-    [self postPath:path parameters:parameters success:^(AFHTTPRequestOperation *operation, id responseJSON) {
+    [self postPath:path parameters:parameters success:^(HatenaAFHTTPRequestOperation *operation, id responseJSON) {
         if (success) {
             success(operation, responseJSON);
         }
-    } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+    } failure:^(HatenaAFHTTPRequestOperation *operation, NSError *error) {
         if (failure) {
             failure(operation, error);
         }
@@ -172,18 +172,18 @@ static NSDictionary * HTBParametersFromQueryString(NSString *queryString) {
 
 // Delete your bookmark.
 - (void)deleteBookmarkWithURL:(NSURL *)bookmarkURL
-                      success:(void (^)(AFHTTPRequestOperation *operation, id responseJSON))success
-                      failure:(void (^)(AFHTTPRequestOperation *operation, NSError *error))failure
+                      success:(void (^)(HatenaAFHTTPRequestOperation *operation, id responseJSON))success
+                      failure:(void (^)(HatenaAFHTTPRequestOperation *operation, NSError *error))failure
 {
     NSString *path = @"/1/my/bookmark.json";
     NSDictionary *parameters = @{
         @"url": [bookmarkURL absoluteString],
     };
-    [self deletePath:path parameters:parameters success:^(AFHTTPRequestOperation *operation, id responseJSON) {
+    [self deletePath:path parameters:parameters success:^(HatenaAFHTTPRequestOperation *operation, id responseJSON) {
         if (success) {
             success(operation, responseJSON);
         }
-    } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+    } failure:^(HatenaAFHTTPRequestOperation *operation, NSError *error) {
         if (failure) {
             failure(operation, error);
         }
@@ -192,18 +192,18 @@ static NSDictionary * HTBParametersFromQueryString(NSString *queryString) {
 
 // Get your bookmarked information.
 - (void)getBookmarkWithURL:(NSURL *)bookmarkURL
-                   success:(void (^)(AFHTTPRequestOperation *operation, id responseJSON))success
-                   failure:(void (^)(AFHTTPRequestOperation *operation, NSError *error))failure
+                   success:(void (^)(HatenaAFHTTPRequestOperation *operation, id responseJSON))success
+                   failure:(void (^)(HatenaAFHTTPRequestOperation *operation, NSError *error))failure
 {
     NSString *path = @"/1/my/bookmark.json";
     NSDictionary *parameters = @{
         @"url": [bookmarkURL absoluteString],
     };
-    [self getPath:path parameters:parameters success:^(AFHTTPRequestOperation *operation, id responseJSON) {
+    [self getPath:path parameters:parameters success:^(HatenaAFHTTPRequestOperation *operation, id responseJSON) {
         if (success) {
             success(operation, responseJSON);
         }
-    } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+    } failure:^(HatenaAFHTTPRequestOperation *operation, NSError *error) {
         if (failure) {
             failure(operation, error);
         }
@@ -211,15 +211,15 @@ static NSDictionary * HTBParametersFromQueryString(NSString *queryString) {
 }
 
 // Get your user information.
-- (void)getMyWithSuccess:(void (^)(AFHTTPRequestOperation *operation, id responseJSON))success
-                 failure:(void (^)(AFHTTPRequestOperation *operation, NSError *error))failure
+- (void)getMyWithSuccess:(void (^)(HatenaAFHTTPRequestOperation *operation, id responseJSON))success
+                 failure:(void (^)(HatenaAFHTTPRequestOperation *operation, NSError *error))failure
 {
     NSString *path = @"/1/my.json";
-    [self getPath:path parameters:nil success:^(AFHTTPRequestOperation *operation, id responseJSON) {
+    [self getPath:path parameters:nil success:^(HatenaAFHTTPRequestOperation *operation, id responseJSON) {
         if (success) {
             success(operation, responseJSON);
         }
-    } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+    } failure:^(HatenaAFHTTPRequestOperation *operation, NSError *error) {
         if (failure) {
             failure(operation, error);
         }
@@ -227,15 +227,15 @@ static NSDictionary * HTBParametersFromQueryString(NSString *queryString) {
 }
 
 // Get your tags.
-- (void)getMyTagsWithSuccess:(void (^)(AFHTTPRequestOperation *operation, id responseJSON))success
-                     failure:(void (^)(AFHTTPRequestOperation *operation, NSError *error))failure
+- (void)getMyTagsWithSuccess:(void (^)(HatenaAFHTTPRequestOperation *operation, id responseJSON))success
+                     failure:(void (^)(HatenaAFHTTPRequestOperation *operation, NSError *error))failure
 {
     NSString *path = @"/1/my/tags.json";
-    [self getPath:path parameters:nil success:^(AFHTTPRequestOperation *operation, id responseJSON) {
+    [self getPath:path parameters:nil success:^(HatenaAFHTTPRequestOperation *operation, id responseJSON) {
         if (success) {
             success(operation, responseJSON);
         }
-    } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+    } failure:^(HatenaAFHTTPRequestOperation *operation, NSError *error) {
         if (failure) {
             failure(operation, error);
         }
@@ -244,19 +244,19 @@ static NSDictionary * HTBParametersFromQueryString(NSString *queryString) {
 
 // Get public entry information.
 - (void)getEntryWithURL:(NSURL *)bookmarkURL
-                   success:(void (^)(AFHTTPRequestOperation *operation, id responseJSON))success
-                   failure:(void (^)(AFHTTPRequestOperation *operation, NSError *error))failure
+                   success:(void (^)(HatenaAFHTTPRequestOperation *operation, id responseJSON))success
+                   failure:(void (^)(HatenaAFHTTPRequestOperation *operation, NSError *error))failure
 {
     NSString *path = @"/1/entry.json";
     NSDictionary *parameters = @{
         @"url": [bookmarkURL absoluteString],
         @"with_tag_recommendations" : @YES,
     };
-    [self getPath:path parameters:parameters success:^(AFHTTPRequestOperation *operation, id responseJSON) {
+    [self getPath:path parameters:parameters success:^(HatenaAFHTTPRequestOperation *operation, id responseJSON) {
         if (success) {
             success(operation, responseJSON);
         }
-    } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+    } failure:^(HatenaAFHTTPRequestOperation *operation, NSError *error) {
         if (failure) {
             failure(operation, error);
         }
@@ -265,16 +265,16 @@ static NSDictionary * HTBParametersFromQueryString(NSString *queryString) {
 
 // Get canonical information.
 - (void)getCanonicalEntryWithURL:(NSURL *)bookmarkURL
-                    success:(void (^)(AFHTTPRequestOperation *operation, id responseJSON))success
-                    failure:(void (^)(AFHTTPRequestOperation *operation, NSError *error))failure
+                    success:(void (^)(HatenaAFHTTPRequestOperation *operation, id responseJSON))success
+                    failure:(void (^)(HatenaAFHTTPRequestOperation *operation, NSError *error))failure
 {
     NSString *path = @"/1/canonical_entry.json";
     NSDictionary *parameters = @{ @"url": [bookmarkURL absoluteString] };
-    [self getPath:path parameters:parameters success:^(AFHTTPRequestOperation *operation, id responseJSON) {
+    [self getPath:path parameters:parameters success:^(HatenaAFHTTPRequestOperation *operation, id responseJSON) {
         if (success) {
             success(operation, responseJSON);
         }
-    } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+    } failure:^(HatenaAFHTTPRequestOperation *operation, NSError *error) {
         if (failure) {
             failure(operation, error);
         }

--- a/SDK/UI/Model/HTBHatenaBookmarkManager.m
+++ b/SDK/UI/Model/HTBHatenaBookmarkManager.m
@@ -28,7 +28,7 @@
 #import "HTBTagEntry.h"
 #import "HTBMyTagsEntry.h"
 #import "HTBUserManager.h"
-#import "AFHTTPRequestOperation.h"
+#import "HatenaAFHTTPRequestOperation.h"
 #import "HTBCanonicalEntry.h"
 
 @implementation HTBHatenaBookmarkManager {
@@ -111,13 +111,13 @@
 - (void)getMyEntryWithSuccess:(void (^)(HTBMyEntry *myEntry))success
                       failure:(void (^)(NSError *error))failure
 {
-    [self.apiClient getMyWithSuccess:^(AFHTTPRequestOperation *operation, id responseJSON) {
+    [self.apiClient getMyWithSuccess:^(HatenaAFHTTPRequestOperation *operation, id responseJSON) {
 
         HTBMyEntry *myEntry = [[HTBMyEntry alloc] initWithJSON:responseJSON];
         self.userManager.myEntry = myEntry;
         if (success) success(myEntry);
             
-    } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+    } failure:^(HatenaAFHTTPRequestOperation *operation, NSError *error) {
 
             // Not Authorize
             if ([operation.response statusCode] == 401) {
@@ -130,11 +130,11 @@
 - (void)getMyTagsWithSuccess:(void (^)(HTBMyTagsEntry *))success
                      failure:(void (^)(NSError *))failure
 {
-    [self.apiClient getMyTagsWithSuccess:^(AFHTTPRequestOperation *operation, id responseJSON) {
+    [self.apiClient getMyTagsWithSuccess:^(HatenaAFHTTPRequestOperation *operation, id responseJSON) {
         HTBMyTagsEntry *myTagsEntry = [[HTBMyTagsEntry alloc]initWithJSON:responseJSON];
         self.userManager.myTagsEntry = myTagsEntry;
             if (success) success(myTagsEntry);
-    } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+    } failure:^(HatenaAFHTTPRequestOperation *operation, NSError *error) {
 
         // Not Authorize
         if ([operation.response statusCode] == 401) {
@@ -148,12 +148,12 @@
                         success:(void (^)(HTBBookmarkEntry *entry))success
                         failure:(void (^)(NSError *error))failure
 {
-    [self.apiClient getEntryWithURL:url success:^(AFHTTPRequestOperation *operation, id responseJSON) {
+    [self.apiClient getEntryWithURL:url success:^(HatenaAFHTTPRequestOperation *operation, id responseJSON) {
 
         HTBBookmarkEntry *entry = [[HTBBookmarkEntry alloc] initWithJSON:responseJSON];
             if (success) success(entry);
 
-        } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+        } failure:^(HatenaAFHTTPRequestOperation *operation, NSError *error) {
             if ([operation.response statusCode] == 404) {
                 NSData *data = [operation.responseString dataUsingEncoding:NSUTF8StringEncoding];
                 if (data) {
@@ -176,12 +176,12 @@
                          success:(void (^)(HTBCanonicalEntry *entry))success
                          failure:(void (^)(NSError *error))failure
 {
-    [self.apiClient getCanonicalEntryWithURL:url success:^(AFHTTPRequestOperation *operation, id responseJSON) {
+    [self.apiClient getCanonicalEntryWithURL:url success:^(HatenaAFHTTPRequestOperation *operation, id responseJSON) {
 
         HTBCanonicalEntry *canonicalEntry = [[HTBCanonicalEntry alloc] initWithJSON:responseJSON];
         if (success) success(canonicalEntry);
 
-    } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+    } failure:^(HatenaAFHTTPRequestOperation *operation, NSError *error) {
 
         // Not Authorize
         if ([operation.response statusCode] == 401) {
@@ -195,12 +195,12 @@
                         success:(void (^)(HTBBookmarkedDataEntry *entry))success
                         failure:(void (^)(NSError *error))failure
 {
-    [self.apiClient getBookmarkWithURL:url success:^(AFHTTPRequestOperation *operation, id responseJSON) {
+    [self.apiClient getBookmarkWithURL:url success:^(HatenaAFHTTPRequestOperation *operation, id responseJSON) {
 
         HTBBookmarkedDataEntry *entry = [[HTBBookmarkedDataEntry alloc] initWithJSON:responseJSON];
         if (success) success(entry);
         
-    } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+    } failure:^(HatenaAFHTTPRequestOperation *operation, NSError *error) {
         if (operation.response.statusCode == 404) {
             // Not bookmarked yet.
             if (success) success(nil);
@@ -223,12 +223,12 @@
                     success:(void (^)(HTBBookmarkedDataEntry *entry))success
                     failure:(void (^)(NSError *error))failure
 {
-    [self.apiClient postBookmarkWithURL:url comment:comment tags:tags options:options success:^(AFHTTPRequestOperation *operation, id responseJSON) {
+    [self.apiClient postBookmarkWithURL:url comment:comment tags:tags options:options success:^(HatenaAFHTTPRequestOperation *operation, id responseJSON) {
         
         HTBBookmarkedDataEntry *entry = [[HTBBookmarkedDataEntry alloc] initWithJSON:responseJSON];
         if (success) success(entry);
 
-    } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+    } failure:^(HatenaAFHTTPRequestOperation *operation, NSError *error) {
 
         // Not Authorize
         if ([operation.response statusCode] == 401) {
@@ -244,11 +244,11 @@
                       success:(void (^)(void))success
                       failure:(void (^)(NSError *error))failure
 {
-    [self.apiClient deleteBookmarkWithURL:url success:^(AFHTTPRequestOperation *operation, id responseJSON) {
+    [self.apiClient deleteBookmarkWithURL:url success:^(HatenaAFHTTPRequestOperation *operation, id responseJSON) {
 
         if (success) success();
 
-    } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+    } failure:^(HatenaAFHTTPRequestOperation *operation, NSError *error) {
 
         // Not Authorize
         if ([operation.response statusCode] == 401) {

--- a/SDK/UI/View/HTBBookmarkEntryView.m
+++ b/SDK/UI/View/HTBBookmarkEntryView.m
@@ -23,7 +23,7 @@
 #import "HTBBookmarkEntryView.h"
 #import <QuartzCore/QuartzCore.h>
 #import "HTBBookmarkEntry.h"
-#import "UIImageView+AFNetworking.h"
+#import "UIImageView+HatenaAFNetworking.h"
 #import "HTBUtility.h"
 
 #define HTB_ENTRY_VIEW_FAVICON_MARGIN 8.f

--- a/SDK/UI/ViewController/HTBBookmarkViewController.m
+++ b/SDK/UI/ViewController/HTBBookmarkViewController.m
@@ -22,7 +22,7 @@
 
 #import "HTBBookmarkViewController.h"
 #import "HTBToggleButton.h"
-#import "UIImageView+AFNetworking.h"
+#import "UIImageView+HatenaAFNetworking.h"
 #import "HTBTagTokenizer.h"
 #import "HTBBookmarkEntryView.h"
 #import "HTBCommentViewController.h"


### PR DESCRIPTION
# 問題

AFNetworkingはバージョン1.x系と2.x系でインターフェース上の互換性が失われました。このため本SDKを使いたいプロジェクトでAFNetworkingも使いたいとき、AFNetworking 2.x系を使おうとするとシンボル名が衝突するなどの問題が起きます。

# 解決

リネームしたAFNetworking 1.xを内包します。乱暴な方法ですがひとまずこれで問題が解決します。

`([[:word:]]*)AF(?!_INET)([[:upper:]_][[:word:]]+)` これらを `$1HatenaAF$2` このように置換しました。今後もAFNetworking 1.xの更新があればそれに追従していく必要があります。

# 注意

この変更を加えることで、SDKのインターフェースの互換性が壊れます。具体的にはこれまでAFNetworkingのオブジェクトが返り値やblockの引数になっていた部分で、プリフィックスが付いたクラス名に変わります。

---

この変更について様々なご意見などあるかと思いますので、本件ついて議論を深めたいと考えています。