### PR TITLE
64bit環境向けにフォーマットを修正

### DIFF
--- a/SDK/UI/Model/Entry/HTBBookmarkEntry.m
+++ b/SDK/UI/Model/Entry/HTBBookmarkEntry.m
@@ -71,7 +71,7 @@
 
 - (NSString *)countUsers
 {
-    return [NSString stringWithFormat:@"%d users", self.count];
+    return [NSString stringWithFormat:@"%ld users", (long)self.count];
 }
 
 @end

--- a/SDK/UI/View/HTBBookmarkRootView.m
+++ b/SDK/UI/View/HTBBookmarkRootView.m
@@ -198,7 +198,7 @@
 - (void)updateTextCount
 {
     NSInteger textCount = ceilf((float)[self.commentTextView.text lengthOfBytesUsingEncoding:NSUTF8StringEncoding] / 3.f);
-    self.textCountLabel.text = [NSString stringWithFormat:@"%d", textCount];
+    self.textCountLabel.text = [NSString stringWithFormat:@"%ld", (long)textCount];
     if (textCount > 100) {
         self.textCountLabel.textColor = [UIColor redColor];
     }


### PR DESCRIPTION
64bit環境では`NSInteger`は`long`として定義されているため，それに合わせてフォーマットを修正．