### PR TITLE
一瞬前回のソーシャルボタン状況が見える問題を修正

### DIFF
--- a/SDK/UI/ViewController/HTBBookmarkViewController.m
+++ b/SDK/UI/ViewController/HTBBookmarkViewController.m
@@ -237,7 +237,6 @@
     HatenaBookmarkPOSTOptions options = self.rootView.toolbarView.selectedPostOptions;
     
     [[HTBHatenaBookmarkManager sharedManager] postBookmarkWithURL:self.URL comment:self.rootView.commentTextView.text tags:tags options:options success:^(HTBBookmarkedDataEntry *entry) {
-        [self setBookmarkedDataEntry:entry];
         [HTBHatenaBookmarkManager sharedManager].userManager.lastPostOptions = options;
         [self.rootView.myBookmarkActivityIndicatorView stopAnimating];
         [(HTBHatenaBookmarkViewController *)self.navigationController.parentViewController dismissHatenaBookmarkViewControllerCompleted:YES];


### PR DESCRIPTION
#64 で報告されていた問題です。
投稿に成功したあと、投稿したブックマーク情報でviewを更新する際に、副作用でブックマーク画面を表示する時点で設定されていたオプションでviewが更新されていました。新しいデータで更新することも考えられますが、閉じる時点でviewを更新する必要性は薄いのでこの処理を省くことで対応しました。